### PR TITLE
refactor : 피드백 반영한 코드 수정

### DIFF
--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -33,7 +33,7 @@ public class ReportController {
 
   @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
   @Operation(summary = "게시글을 이미지와 함께 작성")
-  public ResponseEntity<?> registerReport(
+  public ResponseEntity<ReportDto.Response> registerReport(
 //      Authentication authentication
       @RequestPart ReportDto.Form reportForm,
       @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList
@@ -51,7 +51,7 @@ public class ReportController {
 
   @GetMapping("/{reportId}")
   @Operation(summary = "특정 게시글 정보 가져오기")
-  public ResponseEntity<?> getReport(
+  public ResponseEntity<ReportDto.Response> getReport(
       @PathVariable long reportId
   ) {
 
@@ -62,7 +62,7 @@ public class ReportController {
 
   @GetMapping("/list")
   @Operation(summary = "현재 위치와 인접지역의 게시글 조회")
-  public ResponseEntity<?> getReportList(
+  public ResponseEntity<Slice<ReportList>> getReportList(
       @RequestParam long cursorId,
       @RequestParam double latitude,
       @RequestParam double longitude,
@@ -79,7 +79,7 @@ public class ReportController {
   @PutMapping(value = "/{reportId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
       MediaType.APPLICATION_JSON_VALUE})
   @Operation(summary = "게시글 수정")
-  public ResponseEntity<?> updateReport(
+  public ResponseEntity<ReportDto.Response> updateReport(
 //      Authentication authentication
       @PathVariable long reportId,
       @RequestPart ReportDto.Form reportForm,
@@ -99,7 +99,7 @@ public class ReportController {
 
   @DeleteMapping("/{reportId}")
   @Operation(summary = "게시글 삭제")
-  public ResponseEntity<?> deleteReport(
+  public ResponseEntity<ReportStateDto.Response> deleteReport(
 //      Authentication authentication,
       @PathVariable long reportId
   ) {
@@ -114,7 +114,7 @@ public class ReportController {
 
   @PutMapping("/{reportId}/complete")
   @Operation(summary = "게시글 완료 처리")
-  public ResponseEntity<?> completeProcess(
+  public ResponseEntity<ReportStateDto.Response> completeProcess(
       //      Authentication authentication,
       @PathVariable long reportId
   ) {
@@ -128,7 +128,7 @@ public class ReportController {
 
   @GetMapping("/search")
   @Operation(summary = "게시글 검색")
-  public ResponseEntity<?> searchReport(
+  public ResponseEntity<Slice<ReportList>> searchReport(
       @RequestParam boolean showsInProgressOnly,
       @RequestParam String object,
       Pageable pageable

--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -122,7 +122,7 @@ public class ReportController {
     //TODO: 유저 정보 가져오기 >> Auth 파트 구현 끝나면 수정 필요
     long userId = 1L;
 
-    ReportStateDto.Response foundResponse = reportService.complete(userId, reportId);
+    ReportStateDto.Response foundResponse = reportService.changeStatusToFound(userId, reportId);
     return ResponseEntity.ok(foundResponse);
   }
 

--- a/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
+++ b/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-
   @Query("select r from Report r "
       + "where abs(r.latitude - :latitude) + abs(r.longitude - :longitude) > :cursor "
       + "order by abs(:latitude - r.latitude) + abs(:longitude - r.longitude) ")

--- a/src/main/java/com/samcomo/dbz/report/service/ReportService.java
+++ b/src/main/java/com/samcomo/dbz/report/service/ReportService.java
@@ -21,7 +21,7 @@ public interface ReportService {
 
   Response deleteReport(long userId, long reportId);
 
-  Response complete(long userId, long reportId);
+  Response changeStatusToFound(long userId, long reportId);
 
   Slice<ReportList> search(String object, boolean showsInProgressOnly, Pageable pageable);
 }

--- a/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
@@ -84,15 +84,16 @@ public class ReportServiceImpl implements ReportService {
         .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
 
     report.setViews(report.getViews() + 1);
+    Report newReport = reportRepository.save(report);
 
-    List<ReportImage> reportImageList = reportImageRepository.findAllByReport(report);
+    List<ReportImage> reportImageList = reportImageRepository.findAllByReport(newReport);
     List<ReportImageDto.Response> reportImageResponseList = new ArrayList<>();
 
     for (ReportImage reportImage : reportImageList) {
       reportImageResponseList.add(ReportImageDto.Response.from(reportImage));
     }
 
-    return ReportDto.Response.from(report, reportImageResponseList);
+    return ReportDto.Response.from(newReport, reportImageResponseList);
   }
 
   @Override

--- a/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Repository
@@ -39,7 +38,6 @@ public class ReportServiceImpl implements ReportService {
   private final S3Service s3Service;
 
   @Override
-  @Transactional
   public ReportDto.Response uploadReport(
       long memberId, ReportDto.Form reportForm, List<MultipartFile> multipartFileList
   ) {
@@ -47,24 +45,32 @@ public class ReportServiceImpl implements ReportService {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
-    // 게시글 내용 저장
-    Report newReport = reportRepository.save(Report.from(reportForm, member));
-
-    // 게시글 이미지 저장
+    // S3 이미지 저장
     List<ReportImage> imageList = new ArrayList<>();
     if (!multipartFileList.isEmpty()) {
       for (MultipartFile image : multipartFileList) {
         ImageUploadState imageUploadState = s3Service.upload(image, ImageType.REPORT);
-        checkUploadState(imageUploadState);
-        String imageUrl = imageUploadState.getImageUrl();
 
+        // 이미지 업로드 실패
+        if(!imageUploadState.isSuccess()){
+          //지금까지 저장된 이미지 삭제
+          deleteUploadedImages(imageList);
+
+          throw new ReportException(ErrorCode.IMAGE_UPLOAD_FAIL);
+        }
+
+        String imageUrl = imageUploadState.getImageUrl();
         imageList.add(ReportImage.builder()
-            .report(newReport)
             .imageUrl(imageUrl)
             .build());
       }
     }
 
+    // 게시글 저장
+    Report newReport = reportRepository.save(Report.from(reportForm, member));
+
+    //게시글 이미지 저장
+    imageList.forEach(reportImage -> reportImage.setReport(newReport));
     List<ReportImage> savedImageList = reportImageRepository.saveAll(imageList);
 
     return ReportDto.Response.from(
@@ -142,8 +148,6 @@ public class ReportServiceImpl implements ReportService {
     report.setRoadAddress(reportForm.getRoadAddress());
     report.setShowsPhone(reportForm.isShowsPhone());
 
-    Report newReport = reportRepository.save(report);
-
     // s3이미지 삭제
     List<ReportImage> reportImageList = reportImageRepository.findAllByReport(report);
     for (ReportImage reportImage : reportImageList) {
@@ -156,14 +160,26 @@ public class ReportServiceImpl implements ReportService {
     List<ReportImage> newImageList = new ArrayList<>();
     for (MultipartFile image : imageList) {
       ImageUploadState imageUploadState = s3Service.upload(image, ImageType.REPORT);
-      checkUploadState(imageUploadState);
-      String imageUrl = imageUploadState.getImageUrl();
 
+      // 이미지 업로드 실패
+      if(!imageUploadState.isSuccess()){
+        //지금까지 저장된 이미지 삭제
+        deleteUploadedImages(newImageList);
+
+        throw new ReportException(ErrorCode.IMAGE_UPLOAD_FAIL);
+      }
+
+      String imageUrl = imageUploadState.getImageUrl();
       newImageList.add(ReportImage.builder()
-          .report(newReport)
           .imageUrl(imageUrl)
           .build());
     }
+
+    // 게시글 저장
+    Report newReport = reportRepository.save(report);
+
+    //게시글 이미지 저장
+    newImageList.forEach(reportImage -> reportImage.setReport(newReport));
     List<ReportImage> savedImageList = reportImageRepository.saveAll(newImageList);
 
     return ReportDto.Response.from(
@@ -202,7 +218,7 @@ public class ReportServiceImpl implements ReportService {
   }
 
   @Override
-  public Response complete(long userId, long reportId) {
+  public Response changeStatusToFound(long userId, long reportId) {
 
     Member member = memberRepository.findById(userId)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
@@ -250,16 +266,17 @@ public class ReportServiceImpl implements ReportService {
   }
 
 
-  private void checkUploadState(ImageUploadState imageUploadState) {
+  private boolean checkImageUpload(ImageUploadState imageUploadState) {
 
-    String imageUrl = imageUploadState.getImageUrl();
+    return imageUploadState.isSuccess();
+  }
 
-    if (!imageUploadState.isSuccess()) {
+  private void deleteUploadedImages(List<ReportImage> imageList){
+    for (ReportImage reportImage : imageList){
+      String imageUrl = reportImage.getImageUrl();
       int idx = imageUrl.lastIndexOf("/");
       String fileName = imageUrl.substring(idx + 1);
       s3Service.delete(fileName);
-
-      throw new ReportException(ErrorCode.IMAGE_UPLOAD_FAIL);
     }
   }
 }


### PR DESCRIPTION
## 📌 Issues #12 
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

<br/>

## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
코드 리뷰에서 받은 피드백을 참고하여 코드를 수정했습니다!

#### getReport() 메소드에서 수정된 부분이 반영이 않는 문제
- 수정 후 저장하지 않아 발생한 문제여서 save() 메소드를 사용하여 수정된 Report 를 저장하였습니다.
 > 와일드 카드 삭제
- 와일드 카드를 사용하여 Response 객체를 표시한 부분을 모두 실제 반환 객체로 바꿨습니다.

#### uploadReport() 메소드 로직 수정
- 기존에는 게스글을 저장하고 s3 버킷에 객체를 저장하는 순서로 로직이 동작했습니다.
- 수정 후 s3 버킷에 객체를 먼저 저장하고 게시글을 저장하는 순서로 로직 수정하였습니다. 
- s3 객체에 이미지를 업로드 중 에러가 발생할 경우 롤백하기 위해 트랜잭션을 사용하였지만 s3 객체를 먼저 저장하게 되면서 에러가 발생하면 게시글 저장도 발생하지 않아 트랜잭션을 사용하지 않을 수 있습니다.
<br/>

## 📚 References
<!-- 참고한 자료가 있다면 적어주세요 -->

#### 트랜잭션을 사용하지 않도록 바꾼 이유
- 트랜잭션을 사용하면 데이터베이스의 원자성과 무결성을 보장할 수 있지만 비용이 발생합니다. 하지만 트랜잭션을 관리하며 오버헤드가 발생할 수 있고 **동시성이 높은 환경에서는 트랜잭션 충돌이 발생**할 수 있습니다. 또한 긴시간 동안 트랜잭션이 동작하면 **데이터베이스의 리소스를 오랫동안 점유하게되어 성능문제가 발생**할 수 있습니다.
- 그래서 사용하지 않을 수 있다면 사용않하는게 좋을것이라 판단하였습니다.

#### save() VS saveAll()
- uploadReport() 메소드에서 save(), saveAll() 메소드 사용을 고민했습니다. 현재 상황에서는 큰차이가 없지만 많은 데이터를 저장해야할 수도 있다고 생각해서 saveAll() 메소드를 선택했습니다.
- 트랜잭션이 상위 트랜잭션에 참여하게 되는 특성으로 인해 많은 데이터를 한번에 저장할 때 반복문으로 save() 메소드를 호출하는 것 보다 saveAll() 메소드를 호출하는 것이 효율적입니다. 그래서 saveAll() 메소드를 선택하여 구현했습니다.
- [노션 정리](https://www.notion.so/save-VS-saveAll-b35666a43d374fc68ae7ae6bafc762a5)
<br/>

## To Reviewers
<!-- 팀원에게 전달할 사항이나 질문 등을 자유롭게 적어주세요. -->
- 이번 PR은 따로 시간을 잡아 QnA를 진행하지 않아도 괜찮을거 같아요! 코드만 확인하고 리뷰 부탁드립니다!