### PR TITLE
[#17]refactor: baseEntity 설정 변경

### DIFF
--- a/src/main/java/com/samcomo/dbz/DbzApplication.java
+++ b/src/main/java/com/samcomo/dbz/DbzApplication.java
@@ -2,7 +2,11 @@ package com.samcomo.dbz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
+@EnableWebSecurity
+@EnableJpaAuditing
 @SpringBootApplication
 public class DbzApplication {
 

--- a/src/main/java/com/samcomo/dbz/global/entity/BaseEntity.java
+++ b/src/main/java/com/samcomo/dbz/global/entity/BaseEntity.java
@@ -1,21 +1,23 @@
 package com.samcomo.dbz.global.entity;
 
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
 @Getter
+@MappedSuperclass
+@NoArgsConstructor
 @EntityListeners(value = {AuditingEntityListener.class})
-public class BaseEntity {
+public abstract class BaseEntity {
 
   @CreatedDate
   private LocalDateTime createdAt;
 
   @LastModifiedDate
   private LocalDateTime updatedAt;
-
 }

--- a/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
+++ b/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
@@ -1,27 +1,25 @@
 package com.samcomo.dbz.member.model.entity;
 
 import com.samcomo.dbz.global.entity.BaseEntity;
+import com.samcomo.dbz.member.model.constants.MemberRole;
 import com.samcomo.dbz.member.model.constants.MemberStatus;
-import com.samcomo.dbz.member.model.constants.UserRole;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
-@Builder
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -32,15 +30,35 @@ public class Member extends BaseEntity {
 
   private String nickname;
 
-  private String imageUrl;
+  private String profileImageUrl;
 
   private String phone;
 
   @Enumerated(EnumType.STRING)
-  private UserRole userRole;
+  private MemberRole role;
 
   @Enumerated(EnumType.STRING)
   private MemberStatus status;
 
   private String fcmKey;
+
+  @Builder
+  public Member(Long id, String email, String password, String nickname, String phone,
+      String profileImageUrl, MemberRole role, MemberStatus status, String fcmKey) {
+
+    this.id = id;
+    this.email = email;
+    this.password = password;
+    this.nickname = nickname;
+    this.phone = phone;
+    this.profileImageUrl = profileImageUrl;
+    this.role = role;
+    this.status = status;
+    this.fcmKey = fcmKey;
+  }
+
+  public void encodePassword(PasswordEncoder passwordEncoder, String rawPassword) {
+
+    this.password = passwordEncoder.encode(rawPassword);
+  }
 }


### PR DESCRIPTION
## 📌 Issues #17 
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

close #17 

<br/>

## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

BaseEntity 는 다양한 엔티티의 공통 필드를 담고있는 클래스입니다. 공통 필드의 예시는 생성일자, 수정일자 등이 있습니다.
BaseEntity 를 상속받은 엔티티는 따로 수정하거나 초기화하지 않아도 자동으로 해당 필드의 값이 저장됩니다.
이때 중요한 것은 상속관계의 엔티티의 관계에 초점을 맞추어 어노테이션의 역할, 어노테이션 끼리의 충돌, 어떤 어노테이션이 적합한지 등을 알고 사용해야 합니다.
아래는 제가 제안하는 방식입니다. 다른 의견 혹은 좋은 아이디어가 언제든 환영입니다!

<br/>

[@EnableJpaAuditing 추가]

> BaseEntity 를 상속받은 엔티티의 생성일자와 수정일자가 자동으로 반영되도록 하는 어노테이션을 추가했습니다.

<br/>

[BaseEntity : abstract 클래스로 변경]

> BaseEntity 는 직접 객체를 생성하여 사용하지 않으므로 abstract 클래스로 선언하여 상속하도록 강제했습니다.

<br/>

[부모, 자식 엔티티의 어노테이션 구성 변경]

> 이슈에 상세히 적었습니다. 구현된 코드와 함께 봐주세요!

<br/>

[네이밍 변경]

> imageUrl 은 다소 명확하지 않은 부분이 있어 profileImageUrl 로 변경하는 것을 제안합니다.
>
> user 가 사용된 부분은 member 로 변경했습니다.


- [x] Test 완료 여부

<br/>

## To Reviewers
<!-- 팀원에게 전달할 사항이나 질문 등을 자유롭게 적어주세요. -->

회원가입 구현 로직과 일부 섞여 혼란드려 죄송합니다..! 마지막 줄에 비밀번호 인코딩하는 부분은 다음 pr 때 참고해주세요..ㅎㅎ