### PR TITLE
[Feature/register] 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'

--- a/src/main/java/com/samcomo/dbz/DbzApplication.java
+++ b/src/main/java/com/samcomo/dbz/DbzApplication.java
@@ -2,7 +2,11 @@ package com.samcomo.dbz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
+@EnableWebSecurity
+@EnableJpaAuditing
 @SpringBootApplication
 public class DbzApplication {
 

--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.samcomo.dbz.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+        .csrf((auth) -> auth.disable())
+        .formLogin((auth) -> auth.disable())
+        .httpBasic((auth) -> auth.disable());
+
+    http
+        .authorizeHttpRequests((auth) -> auth
+            .requestMatchers("/member/register").permitAll()
+            .anyRequest().authenticated());
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/samcomo/dbz/global/entity/BaseEntity.java
+++ b/src/main/java/com/samcomo/dbz/global/entity/BaseEntity.java
@@ -1,21 +1,23 @@
 package com.samcomo.dbz.global.entity;
 
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
 @Getter
+@MappedSuperclass
+@NoArgsConstructor
 @EntityListeners(value = {AuditingEntityListener.class})
-public class BaseEntity {
+public abstract class BaseEntity {
 
   @CreatedDate
   private LocalDateTime createdAt;
 
   @LastModifiedDate
   private LocalDateTime updatedAt;
-
 }

--- a/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
+++ b/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
@@ -9,11 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   // Global
-
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다."),
-
   INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
 
   // AWS S3
@@ -24,6 +21,8 @@ public enum ErrorCode {
 
   // Member
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
+  EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 계정입니다."),
+  NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 
   // Report
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/samcomo/dbz/member/controller/MemberController.java
+++ b/src/main/java/com/samcomo/dbz/member/controller/MemberController.java
@@ -1,10 +1,30 @@
 package com.samcomo.dbz.member.controller;
 
+import com.samcomo.dbz.member.model.dto.RegisterDto;
+import com.samcomo.dbz.member.service.impl.MemberServiceImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/member")
+@Tag(name = "회원 관리 컨트롤러", description = "회원 관련 API")
 public class MemberController {
 
+  private final MemberServiceImpl memberService;
+
+  @PostMapping("/register")
+  @Operation(summary = "신규 회원 가입")
+  public ResponseEntity<RegisterDto.Response> register(
+      @RequestBody RegisterDto.Request request
+  ) {
+
+    return ResponseEntity.ok(memberService.register(request));
+  }
 }

--- a/src/main/java/com/samcomo/dbz/member/model/constants/MemberRole.java
+++ b/src/main/java/com/samcomo/dbz/member/model/constants/MemberRole.java
@@ -5,11 +5,11 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum MemberStatus {
+public enum MemberRole {
 
-  DELETED("탈퇴회원"),
-  INACTIVE("휴면회원"),
-  ACTIVE("활성회원");
+  MEMBER("ROLE_MEMBER"),
+  ADMIN("ROLE_ADMIN");
 
-  private final String description;
+  private final String key;
 }
+

--- a/src/main/java/com/samcomo/dbz/member/model/constants/SocialType.java
+++ b/src/main/java/com/samcomo/dbz/member/model/constants/SocialType.java
@@ -1,0 +1,9 @@
+package com.samcomo.dbz.member.model.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum SocialType {
+
+  GOOGLE, KAKAO;
+}

--- a/src/main/java/com/samcomo/dbz/member/model/constants/UserRole.java
+++ b/src/main/java/com/samcomo/dbz/member/model/constants/UserRole.java
@@ -1,6 +1,0 @@
-package com.samcomo.dbz.member.model.constants;
-
-public enum UserRole {
-  ROLE_USER, ROLE_ADMIN
-}
-

--- a/src/main/java/com/samcomo/dbz/member/model/dto/RegisterDto.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/RegisterDto.java
@@ -9,7 +9,6 @@ import com.samcomo.dbz.member.model.entity.Member;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
 public class RegisterDto {
@@ -37,7 +36,6 @@ public class RegisterDto {
 
   @Getter
   @Builder
-  @ToString
   public static class Response {
 
     private Long memberId;
@@ -49,7 +47,6 @@ public class RegisterDto {
 
     @Getter
     @Builder
-    @ToString
     public static class MemberInfo {
 
       private String email;

--- a/src/main/java/com/samcomo/dbz/member/model/dto/RegisterDto.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/RegisterDto.java
@@ -1,0 +1,80 @@
+package com.samcomo.dbz.member.model.dto;
+
+import static com.samcomo.dbz.member.model.constants.MemberRole.MEMBER;
+import static com.samcomo.dbz.member.model.constants.MemberStatus.ACTIVE;
+
+import com.samcomo.dbz.member.model.constants.MemberRole;
+import com.samcomo.dbz.member.model.constants.MemberStatus;
+import com.samcomo.dbz.member.model.entity.Member;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+public class RegisterDto {
+
+  @Getter
+  @Builder
+  public static class Request {
+
+    private String email;
+    private String nickname;
+    private String phone;
+    private String password;
+
+    public static Member toEntity(Request request) {
+      return Member.builder()
+          .email(request.getEmail())
+          .nickname(request.getNickname())
+          .profileImageUrl("defaultImageUrl.jpg") // TODO 기본 이미지 url 정하기
+          .phone(request.getPhone())
+          .role(MEMBER)
+          .status(ACTIVE)
+          .build();
+    }
+  }
+
+  @Getter
+  @Builder
+  @ToString
+  public static class Response {
+
+    private Long memberId;
+    private MemberInfo memberInfo;
+    private MemberStatus status;
+    private MemberRole role;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Getter
+    @Builder
+    @ToString
+    public static class MemberInfo {
+
+      private String email;
+      private String nickname;
+      private String profileImageUrl;
+      private String phone;
+    }
+
+    public static Response fromEntity(Member member) {
+
+      return Response.builder()
+          .memberId(member.getId())
+          .memberInfo(
+              MemberInfo.builder()
+                  .email(member.getEmail())
+                  .nickname(member.getNickname())
+                  .profileImageUrl(member.getProfileImageUrl())
+                  .phone(member.getPhone())
+                  .build())
+          .status(member.getStatus())
+          .role(member.getRole())
+          .createdAt(member.getCreatedAt())
+          .updatedAt(member.getUpdatedAt())
+          .build();
+    }
+  }
+}
+

--- a/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
+++ b/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
@@ -1,27 +1,25 @@
 package com.samcomo.dbz.member.model.entity;
 
 import com.samcomo.dbz.global.entity.BaseEntity;
+import com.samcomo.dbz.member.model.constants.MemberRole;
 import com.samcomo.dbz.member.model.constants.MemberStatus;
-import com.samcomo.dbz.member.model.constants.UserRole;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
-@Builder
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -32,15 +30,35 @@ public class Member extends BaseEntity {
 
   private String nickname;
 
-  private String imageUrl;
+  private String profileImageUrl;
 
   private String phone;
 
   @Enumerated(EnumType.STRING)
-  private UserRole userRole;
+  private MemberRole role;
 
   @Enumerated(EnumType.STRING)
   private MemberStatus status;
 
   private String fcmKey;
+
+  @Builder
+  public Member(Long id, String email, String password, String nickname, String phone,
+      String profileImageUrl, MemberRole role, MemberStatus status, String fcmKey) {
+
+    this.id = id;
+    this.email = email;
+    this.password = password;
+    this.nickname = nickname;
+    this.phone = phone;
+    this.profileImageUrl = profileImageUrl;
+    this.role = role;
+    this.status = status;
+    this.fcmKey = fcmKey;
+  }
+
+  public void encodePassword(PasswordEncoder passwordEncoder, String rawPassword) {
+
+    this.password = passwordEncoder.encode(rawPassword);
+  }
 }

--- a/src/main/java/com/samcomo/dbz/member/model/repository/MemberRepository.java
+++ b/src/main/java/com/samcomo/dbz/member/model/repository/MemberRepository.java
@@ -1,8 +1,12 @@
 package com.samcomo.dbz.member.model.repository;
 
 import com.samcomo.dbz.member.model.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
 
+  Optional<Member> findByEmail(String email);
+
+  Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/samcomo/dbz/member/service/MemberService.java
+++ b/src/main/java/com/samcomo/dbz/member/service/MemberService.java
@@ -1,8 +1,12 @@
 package com.samcomo.dbz.member.service;
 
+import com.samcomo.dbz.member.model.dto.RegisterDto;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface MemberService {
 
+  RegisterDto.Response register(RegisterDto.Request request);
+
+  void validateDuplicateMember(String email, String nickname);
 }

--- a/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
@@ -1,10 +1,46 @@
 package com.samcomo.dbz.member.service.impl;
 
+import static com.samcomo.dbz.global.exception.ErrorCode.EMAIL_ALREADY_EXISTS;
+import static com.samcomo.dbz.global.exception.ErrorCode.NICKNAME_ALREADY_EXISTS;
+
+import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.model.dto.RegisterDto;
+import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.member.model.repository.MemberRepository;
+import com.samcomo.dbz.member.service.MemberService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MemberServiceImpl {
+public class MemberServiceImpl implements MemberService {
 
+  private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  @Transactional
+  public RegisterDto.Response register(RegisterDto.Request request) {
+
+    validateDuplicateMember(request.getEmail(), request.getNickname());
+
+    Member member = RegisterDto.Request.toEntity(request);
+    member.encodePassword(passwordEncoder, request.getPassword());
+
+    member = memberRepository.save(member);
+
+    return RegisterDto.Response.fromEntity(member);
+  }
+
+  public void validateDuplicateMember(String email, String nickname) {
+
+    if (memberRepository.findByEmail(email).isPresent()) {
+      throw new MemberException(EMAIL_ALREADY_EXISTS);
+    }
+    if (memberRepository.findByNickname(nickname).isPresent()) {
+      throw new MemberException(NICKNAME_ALREADY_EXISTS);
+    }
+  }
 }

--- a/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
@@ -1,0 +1,89 @@
+package com.samcomo.dbz.member.controller;
+
+import static com.samcomo.dbz.member.model.constants.MemberRole.MEMBER;
+import static com.samcomo.dbz.member.model.constants.MemberStatus.ACTIVE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samcomo.dbz.member.model.dto.RegisterDto;
+import com.samcomo.dbz.member.model.dto.RegisterDto.Response.MemberInfo;
+import com.samcomo.dbz.member.service.impl.MemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+  @MockBean
+  private MemberServiceImpl memberService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @WithMockUser(username = "테스트 관리자", roles = {"SUPER"})
+  @DisplayName(value = "[성공] 회원가입")
+  void successRegister() throws Exception {
+    // given
+    RegisterDto.Request request = getRequestExample();
+    RegisterDto.Response response = getResponseExample();
+
+    given(memberService.register(any(RegisterDto.Request.class)))
+        .willReturn(response);
+
+    // when
+    // then
+    mockMvc.perform(
+            post("/member/register")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("memberInfo.email").value("samcomo@gmail.com"))
+        .andExpect(jsonPath("memberInfo.nickname").value("삼코모"))
+        .andExpect(jsonPath("memberInfo.phone").value("010-1234-5678"))
+        .andExpect(jsonPath("status").value("ACTIVE"))
+        .andExpect(jsonPath("role").value("MEMBER"))
+        .andDo(print());
+  }
+
+  private RegisterDto.Request getRequestExample() {
+
+    return RegisterDto.Request.builder()
+        .email("samcomo@gmail.com")
+        .nickname("삼코모")
+        .phone("010-1234-5678")
+        .password("123")
+        .build();
+  }
+
+  private RegisterDto.Response getResponseExample() {
+
+    return RegisterDto.Response.builder()
+        .memberInfo(
+            MemberInfo.builder()
+                .email("samcomo@gmail.com")
+                .nickname("삼코모")
+                .phone("010-1234-5678")
+                .build())
+        .status(ACTIVE)
+        .role(MEMBER)
+        .build();
+  }
+}

--- a/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.samcomo.dbz.member.model.dto.RegisterDto;
 import com.samcomo.dbz.member.model.dto.RegisterDto.Response.MemberInfo;
 import com.samcomo.dbz.member.service.impl.MemberServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,14 +36,42 @@ class MemberControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
+  private RegisterDto.Request request;
+  private RegisterDto.Response response;
+  private String rawEmail;
+  private String rawNickname;
+  private String rawPhone;
+
+  @BeforeEach
+  void init() {
+
+    rawEmail = "samcomo@gmail.com";
+    rawPhone = "010-1234-5678";
+    rawNickname = "삼코모";
+
+    request = RegisterDto.Request.builder()
+        .email(rawEmail)
+        .nickname(rawNickname)
+        .phone(rawPhone)
+        .build();
+
+    response = RegisterDto.Response.builder()
+        .memberInfo(
+            MemberInfo.builder()
+                .email("samcomo@gmail.com")
+                .nickname("삼코모")
+                .phone("010-1234-5678")
+                .build())
+        .status(ACTIVE)
+        .role(MEMBER)
+        .build();
+  }
+
   @Test
   @WithMockUser(username = "테스트 관리자", roles = {"SUPER"})
   @DisplayName(value = "[성공] 회원가입")
   void successRegister() throws Exception {
     // given
-    RegisterDto.Request request = getRequestExample();
-    RegisterDto.Response response = getResponseExample();
-
     given(memberService.register(any(RegisterDto.Request.class)))
         .willReturn(response);
 
@@ -55,35 +84,11 @@ class MemberControllerTest {
                 .content(
                     objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("memberInfo.email").value("samcomo@gmail.com"))
-        .andExpect(jsonPath("memberInfo.nickname").value("삼코모"))
-        .andExpect(jsonPath("memberInfo.phone").value("010-1234-5678"))
+        .andExpect(jsonPath("memberInfo.email").value(rawEmail))
+        .andExpect(jsonPath("memberInfo.nickname").value(rawNickname))
+        .andExpect(jsonPath("memberInfo.phone").value(rawPhone))
         .andExpect(jsonPath("status").value("ACTIVE"))
         .andExpect(jsonPath("role").value("MEMBER"))
         .andDo(print());
-  }
-
-  private RegisterDto.Request getRequestExample() {
-
-    return RegisterDto.Request.builder()
-        .email("samcomo@gmail.com")
-        .nickname("삼코모")
-        .phone("010-1234-5678")
-        .password("123")
-        .build();
-  }
-
-  private RegisterDto.Response getResponseExample() {
-
-    return RegisterDto.Response.builder()
-        .memberInfo(
-            MemberInfo.builder()
-                .email("samcomo@gmail.com")
-                .nickname("삼코모")
-                .phone("010-1234-5678")
-                .build())
-        .status(ACTIVE)
-        .role(MEMBER)
-        .build();
   }
 }

--- a/src/test/java/com/samcomo/dbz/member/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/samcomo/dbz/member/service/impl/MemberServiceImplTest.java
@@ -1,0 +1,152 @@
+package com.samcomo.dbz.member.service.impl;
+
+import static com.samcomo.dbz.global.exception.ErrorCode.EMAIL_ALREADY_EXISTS;
+import static com.samcomo.dbz.global.exception.ErrorCode.NICKNAME_ALREADY_EXISTS;
+import static com.samcomo.dbz.member.model.constants.MemberRole.MEMBER;
+import static com.samcomo.dbz.member.model.constants.MemberStatus.ACTIVE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.model.dto.RegisterDto;
+import com.samcomo.dbz.member.model.dto.RegisterDto.Response.MemberInfo;
+import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.member.model.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceImplTest {
+
+  @InjectMocks
+  private MemberServiceImpl memberService;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Spy
+  private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  void init() {
+    passwordEncoder = new BCryptPasswordEncoder();
+  }
+
+  @Test
+  @DisplayName(value = "[성공] 회원가입")
+  void successRegister() {
+    // given
+    RegisterDto.Request request = getRequestExample();
+    Member savedMember = getSavedMemberExample("123");
+
+    given(memberRepository.save(any()))
+        .willReturn(savedMember);
+
+    ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+
+    // when
+    RegisterDto.Response response = memberService.register(request);
+
+    // then
+    verify(memberRepository, times(1)).save(captor.capture());
+
+    assertEquals(1L, response.getMemberId());
+    assertEquals("samcomo@gmail.com", response.getMemberInfo().getEmail());
+    assertEquals("삼코모", response.getMemberInfo().getNickname());
+    assertEquals("010-1234-5678", response.getMemberInfo().getPhone());
+
+    assertEquals(ACTIVE, response.getStatus());
+    assertEquals(MEMBER, response.getRole());
+
+    assertTrue(passwordEncoder.matches("123", savedMember.getPassword()));
+  }
+
+  @Test
+  @DisplayName(value = "[실패] 회원가입-유효성검사 : 이메일 중복")
+  void failValidateDuplicateMember_EmailException() {
+    // given
+    Member alreadyExistsMember = getSavedMemberExample("123");
+    RegisterDto.Request request = getRequestExample();
+
+    given(memberRepository.findByEmail(any()))
+        .willReturn(Optional.of(alreadyExistsMember));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> memberService.register(request));
+
+    // then
+    assertEquals(EMAIL_ALREADY_EXISTS, memberException.getErrorCode());
+  }
+
+  @Test
+  @DisplayName(value = "[실패] 회원가입-유효성검사 : 닉네임 중복")
+  void failValidateDuplicateMember_NicknameException() {
+    // given
+    Member alreadyExistsMember = getSavedMemberExample("123");
+    RegisterDto.Request request = getRequestExample();
+
+    given(memberRepository.findByNickname(any()))
+        .willReturn(Optional.of(alreadyExistsMember));
+
+    // when
+    MemberException memberException = assertThrows(MemberException.class,
+        () -> memberService.register(request));
+
+    // then
+    assertEquals(NICKNAME_ALREADY_EXISTS, memberException.getErrorCode());
+  }
+
+  private Member getSavedMemberExample(String rawPassword) {
+
+    return Member.builder()
+        .id(1L)
+        .email("samcomo@gmail.com")
+        .nickname("삼코모")
+        .phone("010-1234-5678")
+        .profileImageUrl("defaultImageUrl.jpg")
+        .password(passwordEncoder.encode(rawPassword))
+        .role(MEMBER)
+        .status(ACTIVE)
+        .build();
+  }
+
+  private RegisterDto.Request getRequestExample() {
+
+    return RegisterDto.Request.builder()
+        .email("samcomo@gmail.com")
+        .nickname("삼코모")
+        .phone("010-1234-5678")
+        .password("123")
+        .build();
+  }
+
+  private RegisterDto.Response getResponseExample() {
+
+    return RegisterDto.Response.builder()
+        .memberInfo(
+            MemberInfo.builder()
+                .email("samcomo@gmail.com")
+                .nickname("삼코모")
+                .phone("010-1234-5678")
+                .build())
+        .status(ACTIVE)
+        .role(MEMBER)
+        .build();
+  }
+}


### PR DESCRIPTION
## 📌 Issues #16 
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

close #16 

<br/>

## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

[전체 플로우]

클라이언트가 회원가입에 필요한 정보와 함께 회원가입 요청을 보냅니다. 넘어오는 데이터는 아래와 같습니다.
```
{
    "email": "samcomo@gmail.com",
    "nickname" : "삼코모",
    "phone": "010-1234-5678",
    "password" : "123"
}
```
이에 추가적으로 서버에서는 회원의 권한과 접속상태, 생성일자/수정일자 정보를 초기화하여 DB 에 저장합니다.
저장 후 다시 클라이언트로 응답을 보냅니다.
```
{
    "memberId": 1,
    "memberInfo": {
        "email": "samcomo@gmail.com",
        "nickname": "삼코모",
        "profileImageUrl": "기본이미지 url",
        "phone": "010-1234-5678"
    },
    "status": "ACTIVE",
    "role": "MEMBER",
    "createdAt": "2024-03-03T00:25:35.196872",
    "updatedAt": "2024-03-03T00:25:35.196893"
}
```

<br/>

[서버 플로우]

**-데이터 검증-**
클라이언트에서 요청이 오면 우선적으로 각 데이터 자체의 유효성 검정이 필요합니다. 이 부분은 다른 pr 로 올릴 예정입니다.

**-회원중복 검증-**
데이터 검증이 통과되면 회원 중복 검증이 진행됩니다. email 혹은 nickname 이 기존의 회원과 겹치면 MemberException 이 발생합니다.

**-데이터 가공-**
클라이언트에서 받은 데이터는 서버에서 가공되어 DB 에 저장됩니다. 가공되는 사항은 아래와 같습니다.
- 비밀번호 인코딩 (BCryptPasswordEncoder)
- 권한 설정 (MEMBER)
- 회원 상태 설정 (ACTIVE)

**-회원가입 진행-**
중복 검증까지 통과되면 서버에 회원 정보를 저장합니다.

[이후 구현할 기능 리스트]

- [ ] 소셜로그인으로 로그인만 할 경우 회원권한을 GUEST 로 할당한다. (소셜로그인 후 가입 시 MEMBER로 변환)
- [ ] 소셜로그인 상태로 접근했을 때의 신규 회원가입
- [ ] email, phone, password, nickname 의 유효성 검증 로직
- [ ] 회원가입 시 기본 이미지 url 초기화
- [ ] fcm 키 관련 로직

<br/>

[테스트]

- [x] `SpringBootTest` 대신 Mock 테스트 작성을 통해 테스트 효율성을 높였습니다.

<br/>

## To Reviewers
<!-- 팀원에게 전달할 사항이나 질문 등을 자유롭게 적어주세요. -->

이전 #17 관련 pr 의 내용과 같이 올라갑니다! 충돌이 날까 무섭긴 한데 잘 해결해서 머지하겠습니다!
혹시 pr 단위가 크면 커밋단위로 확인해주세요! pr 단위를 줄였는데요 생각보다 파일 내용이 많네요..!