### PR TITLE
hotfix: jpa metadata empty 에러

### DIFF
--- a/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
@@ -20,11 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(MemberController.class)
+@MockBean(JpaMetamodelMappingContext.class)
 class MemberControllerTest {
 
   @MockBean


### PR DESCRIPTION
- MemberController 테스트 시 발생하는 에러 해결

## 📌 Issues #24 
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

close #24 

<br/>

## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

### [원인]

<br/>

#### #에러 로그

```java
// error summary

Caused by: org.springframework.beans.factory.BeanCreationException: 
  Error creating bean with name 'jpaAuditingHandler': 
    Cannot resolve reference to bean 'jpaMappingContext' while setting constructor argument

Caused by: org.springframework.beans.factory.BeanCreationException: 
  Error creating bean with name 'jpaMappingContext': 
    JPA metamodel must not be empty

Caused by: java.lang.IllegalArgumentException: 
  JPA metamodel must not be empty
```

<br/>

#### #공식문서

![스크린샷 2024-03-05 오후 10 38 19](https://github.com/SamCoMo/DBZ-Backend/assets/126454114/b3ae36f7-9fd2-431a-ba9f-95bf340d8d0e)

먼저 공식문서를 찾아보니 `MappingContext` 는 엔티티 간의 연결정보를 매핑하는 인터페이스고, `jpaMappingContext` 는 jpa 엔티티의 연결정보를 매핑하는 구현체임을 알 수 있었다.

위 에러메시지를 다시 보니 에러상황을 대충 추측할 수 있었다.
`jpaAuditingHandler` 빈을 등록하던 도중 `jpaMappingContext` 때문에 에러가 발생했고, `jpaMappingContext` 빈 또한 jpa 엔티티 연결정보가 없어서 문제가 발생한 것 같다. 이를 토대로 디버깅을 통해 문제를 알아봤다.

<br/>

#### #디버깅

```java
@EnableWebSecurity
@EnableJpaAuditing
@SpringBootApplication
public class DbzApplication {
```

문제가 되었던 `jpaAuditingHandler` 는 위 `EnableJpaAuditing` 에서 오지 않았을까 생각하고 어노테이션을 분석해봤다.  


```java
@Documented
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
@Import(JpaAuditingRegistrar.class)
public @interface EnableJpaAuditing {
```

`JpaAuditingRegistrar.class` 를 임포트하는 듯 하다. 수상하니 까보았다!

```java
class JpaAuditingRegistrar extends AuditingBeanDefinitionRegistrarSupport {

  ...
  
  @Override
    protected String getAuditingHandlerBeanName() {
    return "jpaAuditingHandler";
  }
  ...
}
```

문제가 됐던 `jpaAuditingHandler` 가 `@EnableJpaAuditing` 에서 발생되었다는 예상이 맞았다.

<br/>

![스크린샷 2024-03-05 오후 10 47 18](https://github.com/SamCoMo/DBZ-Backend/assets/126454114/1fbdc7ab-84fe-4a54-ad74-e777b2b94ab7)

이번엔 디버깅 로그를 따라가보았다.

```java
// AbstractAutowireCapableBeanFactory.initializeBean

try {
  // 빈을 등록하는 메소드가 try 문에 감싸져있다.
  invokeInitMethods(beanName, wrappedBean, mbd);
  }
  catch (Throwable ex) {
    throw new BeanCreationException( ... );
 }
```

```java
protected void invokeInitMethods(...) throws Throwable {
  ...
	  ((InitializingBean) bean).afterPropertiesSet(); // 이 메소드는 들어가보니 interface 의 메소드였다. 아래가 그 구현체이다.
  ...
}
```

```java
@Override
  public void afterPropertiesSet() throws Exception {
    if (isSingleton()) {
      ...
      this.singletonInstance = createInstance(); // 이 메소드는 abstract 였고, 아래가 그 구현체다.
      ...
    }
  }
```

```java
@Override
protected JpaMetamodelMappingContext createInstance() {

  ...
  JpaMetamodelMappingContext context = new JpaMetamodelMappingContext(getMetamodels());
  ...
}
```

```java
public JpaMetamodelMappingContext(Set<Metamodel> models) {

  Assert.notNull(models, "JPA metamodel must not be null");
  Assert.notEmpty(models, "JPA metamodel must not be empty");
  
  this.models = new Metamodels(models);
  this.persistenceProvider = PersistenceProvider.fromMetamodel(models.iterator().next());
}
```

분명 에러로그에서 봤던 메시지다! 여기서 에러가 발생했고 원인은 필수 매개변수인 models 가 비어있기 때문이라는 예상이 맞았다.

<br/>

### [결론]

문제의 원인이 `@EnableJpaAuditing` 때문이라는 것을 알았고, 테스트가 Mock 데이터이기 때문에 가짜 객체를 만들면서 `JpaMetamodelMappingContext` 에 필요한 models 매개변수가 할당되지 않아 empty 에러가 발생했다.

<br/>

### [해결방법]

1. 문제가 되는 `@EnableJpaAuditing` 을 제거한다. -> 이건 안 된다. 실제 프로젝트에선 필요하기 때문!
2. 따로 config 클래스를 만들어 어노테이션을 붙여준다.
테스트 실행 시 DbzApplication.java 를 스캔하기 때문에 여기에만 `@EnableJpaAuditing` 만 없으면 해결된다.
3. 테스트 코드에 MockBean 으로 JpaMetamodelMappingContext 등록하여 가짜 빈을 등록한다.

2번은 어노테이션 하나때문에 따로 클래스를 생성해야 해서 3번 방법을 선택했다!

```java
@WebMvcTest(MemberController.class)
@MockBean(JpaMetamodelMappingContext.class)
class MemberControllerTest {
```

성공!

<br/>

## 📚 References
<!-- 참고한 자료가 있다면 적어주세요 -->

[MappingContext 인터패이스 docs](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/mapping/context/MappingContext.html)

[JpaMetamodelMappingContext 구현체 docs](https://docs.spring.io/spring-data/data-jpa/docs/current/api/org/springframework/data/jpa/mapping/JpaMetamodelMappingContext.html)