### PR TITLE
refactor: 게시글 리스트 조회 메소드 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,11 @@ dependencies {
 	// maria DB
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
-	//AWS
+	// AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/samcomo/dbz/DbzApplication.java
+++ b/src/main/java/com/samcomo/dbz/DbzApplication.java
@@ -2,12 +2,14 @@ package com.samcomo.dbz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @EnableWebSecurity
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableCaching
 public class DbzApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -1,11 +1,20 @@
 package com.samcomo.dbz.global.config;
 
+import com.samcomo.dbz.member.model.jwt.JwtUtil;
+import com.samcomo.dbz.member.model.jwt.filter.JwtFilter;
+import com.samcomo.dbz.member.model.jwt.filter.LoginFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
     // mapping
     http
         .authorizeHttpRequests((auth) -> auth
+            .requestMatchers("/member/register").permitAll()
+            .requestMatchers("/report/**").permitAll()
             .requestMatchers("/member/register", "/member/login").permitAll()
             .requestMatchers("/member/test").hasRole("MEMBER")
             .anyRequest().authenticated());

--- a/src/main/java/com/samcomo/dbz/global/redis/RedisCacheConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/redis/RedisCacheConfig.java
@@ -1,0 +1,34 @@
+package com.samcomo.dbz.global.redis;
+
+import com.samcomo.dbz.report.model.dto.CustomSlice;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+@Configuration
+public class RedisCacheConfig {
+
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory){
+    RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(
+                new Jackson2JsonRedisSerializer<>(String.class)
+            )
+        )
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(
+                new Jackson2JsonRedisSerializer<>(CustomSlice.class)
+            )
+        );
+    return RedisCacheManager.RedisCacheManagerBuilder
+        .fromConnectionFactory(redisConnectionFactory)
+        .cacheDefaults(redisCacheConfiguration)
+        .build();
+  }
+
+}

--- a/src/main/java/com/samcomo/dbz/global/redis/RedisConfiguration.java
+++ b/src/main/java/com/samcomo/dbz/global/redis/RedisConfiguration.java
@@ -1,0 +1,21 @@
+package com.samcomo.dbz.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfiguration {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory(){
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+  }
+}

--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.samcomo.dbz.report.controller;
 
+import com.samcomo.dbz.report.model.dto.CustomSlice;
 import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportList;
 import com.samcomo.dbz.report.model.dto.ReportStateDto;
@@ -9,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -62,16 +62,17 @@ public class ReportController {
 
   @GetMapping("/list")
   @Operation(summary = "현재 위치와 인접지역의 게시글 조회")
-  public ResponseEntity<Slice<ReportList>> getReportList(
-      @RequestParam long cursorId,
-      @RequestParam double latitude,
-      @RequestParam double longitude,
+  public ResponseEntity<CustomSlice<ReportList>> getReportList(
+      @RequestParam double lastLatitude,
+      @RequestParam double lastLongitude,
+      @RequestParam double curLatitude,
+      @RequestParam double curLongitude,
       @RequestParam boolean showsInProcessOnly,
       Pageable pageable
   ) {
 
-    Slice<ReportList> result =
-        reportService.getReportList(cursorId, latitude, longitude, showsInProcessOnly, pageable);
+    CustomSlice<ReportList> result =
+        reportService.getReportList(lastLongitude, lastLatitude, curLatitude, curLongitude, showsInProcessOnly, pageable);
 
     return ResponseEntity.ok(result);
   }
@@ -128,13 +129,13 @@ public class ReportController {
 
   @GetMapping("/search")
   @Operation(summary = "게시글 검색")
-  public ResponseEntity<Slice<ReportList>> searchReport(
+  public ResponseEntity<CustomSlice<ReportList>> searchReport(
       @RequestParam boolean showsInProgressOnly,
       @RequestParam String object,
       Pageable pageable
   ){
 
-    Slice<ReportList> result = reportService.searchReport(object, showsInProgressOnly, pageable);
+    CustomSlice<ReportList> result = reportService.searchReport(object, showsInProgressOnly, pageable);
 
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/com/samcomo/dbz/report/model/dto/CustomPageable.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/CustomPageable.java
@@ -1,0 +1,15 @@
+package com.samcomo.dbz.report.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomPageable {
+
+  private int pageNumber;
+  private int pageSize;
+
+}

--- a/src/main/java/com/samcomo/dbz/report/model/dto/CustomSlice.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/CustomSlice.java
@@ -1,0 +1,21 @@
+package com.samcomo.dbz.report.model.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomSlice<T> {
+
+  private List<T> content;
+  private CustomPageable pageable;
+  private boolean first;
+  private boolean last;
+  private int number;
+  private int size;
+  private int numberOfElements;
+
+}

--- a/src/main/java/com/samcomo/dbz/report/model/dto/ReportList.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/ReportList.java
@@ -27,6 +27,7 @@ public class ReportList {
   private String feature;
   private String streetAddress;
   private String roadAddress;
+  private double lastDistance;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
   private String imageUrl;

--- a/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
+++ b/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
@@ -2,23 +2,34 @@ package com.samcomo.dbz.report.model.repository;
 
 import com.samcomo.dbz.report.model.constants.ReportStatus;
 import com.samcomo.dbz.report.model.entity.Report;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-  @Query("select r from Report r "
-      + "where abs(r.latitude - :latitude) + abs(r.longitude - :longitude) > :cursor "
-      + "order by abs(:latitude - r.latitude) + abs(:longitude - r.longitude) ")
-  Slice<Report> findAllOrderByDistance(@Param("cursor") long cursor, @Param("latitude") double latitude, @Param("longitude") double longitude, Pageable pageable);
 
-  @Query("select r from Report r "
-      + "where r.reportStatus = 'PUBLISHED' "
-      + "and abs(r.latitude - :latitude) + abs(r.longitude - :longitude) > :cursor "
-      + "order by abs(:latitude - r.latitude) + abs(:longitude - r.longitude) ")
-  Slice<Report> findAllInProcessOrderByDistance(@Param("cursor") long cursor, @Param("latitude") double latitude, @Param("longitude") double longitude, Pageable pageable);
+  @Query(value = "select r "
+      + "from Report r "
+      + "where ST_Distance_Sphere(Point(r.longitude, r.latitude), Point(:curLongitude, :curLatitude)) > "
+      + " ST_Distance_Sphere(Point(:lastLongitude, :lastLatitude), Point(:curLongitude, :curLatitude)) "
+      + "order by ST_Distance_Sphere(Point(r.longitude, r.latitude), Point(:curLongitude, :curLatitude)) ")
+  Slice<Report> findAllOrderByDistance(
+      @Param("lastLatitude") double lastLatitude, @Param("lastLongitude") double lastLongitude,
+      @Param("curLatitude") double curLatitude, @Param("curLongitude") double curLongitude,
+      Pageable pageable);
+
+  @Query(value = "select r "
+      + "from Report r "
+      + "where ST_Distance_Sphere(Point(r.longitude, r.latitude), Point(:curLongitude, :curLatitude)) > "
+      + " ST_Distance_Sphere(Point(r.longitude, r.latitude), Point(:curLongitude, :curLatitude)) and r.reportStatus = 'PUBLISHED'"
+      + "order by ST_Distance_Sphere(Point(:lastLongitude, :lastLatitude), Point(:curLongitude, :curLatitude)) ")
+  Slice<Report> findAllInProcessOrderByDistance(
+      @Param("lastLatitude") double lastLatitude, @Param("lastLongitude") double lastLongitude,
+      @Param("curLatitude") double curLatitude, @Param("curLongitude") double curLongitude,
+      Pageable pageable);
+
 
   Slice<Report> findAllByTitleContainsOrPetNameContainsOrSpeciesContains(String title, String petName, String species, Pageable pageable);
 

--- a/src/main/java/com/samcomo/dbz/report/service/ReportService.java
+++ b/src/main/java/com/samcomo/dbz/report/service/ReportService.java
@@ -1,11 +1,11 @@
 package com.samcomo.dbz.report.service;
 
+import com.samcomo.dbz.report.model.dto.CustomSlice;
 import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportList;
 import com.samcomo.dbz.report.model.dto.ReportStateDto.Response;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ReportService {
@@ -14,8 +14,8 @@ public interface ReportService {
 
   ReportDto.Response getReport(long reportId);
 
-  Slice<ReportList> getReportList(
-      long cursorId, double latitude, double longitude, boolean showsInProcessOnly, Pageable pageable);
+  CustomSlice<ReportList> getReportList(
+      double lastLatitude, double lastLongitude, double curLatitude, double curLongitude, boolean showsInProcessOnly, Pageable pageable);
 
   ReportDto.Response updateReport(long reportId, ReportDto.Form reportForm, List<MultipartFile> imageList, long userId);
 
@@ -23,5 +23,5 @@ public interface ReportService {
 
   Response changeStatusToFound(long userId, long reportId);
 
-  Slice<ReportList> searchReport(String object, boolean showsInProgressOnly, Pageable pageable);
+  CustomSlice<ReportList> searchReport(String object, boolean showsInProgressOnly, Pageable pageable);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,8 +1,8 @@
 spring:
   data:
     redis:
-      host:
-      password:
+      port: 6389
+      host: localhost
 
   datasource:
     url: jdbc:mariadb://localhost:3308/samcomo

--- a/src/main/resources/sql/reportDumy.sql
+++ b/src/main/resources/sql/reportDumy.sql
@@ -3,8 +3,8 @@
 insert into member (id)
 values (1);
 
-delimiter //
-drop procedure if exists loopinsert//
+delimiter $$
+drop procedure if exists loopinsert$$
 
 create procedure loopinsert()
 begin
@@ -12,7 +12,7 @@ begin
     declare sp VARCHAR(10);
     declare rs varchar(50);
 
-    while i <= 500
+    while i <= 50000
         do
             set sp = IF(rand() < 0.5, 'DOG', 'CAT');
             set rs = if(rand() < 0.33, 'PUBLISHED', if(rand() < 0.67, 'DELETED', 'FOUND'));
@@ -27,7 +27,7 @@ begin
         end while;
 
     set i = 1;
-    while i <= 500
+    while i <= 50000
         do
             set sp = IF(rand() < 0.5, 'DOG', 'CAT');
             set rs = if(rand() < 0.33, 'PUBLISHED', if(rand() < 0.67, 'DELETED', 'FOUND'));
@@ -42,7 +42,7 @@ begin
         end while;
 
     set i = 1;
-    while i <= 500
+    while i <= 50000
         do
             set sp = IF(rand() < 0.5, 'DOG', 'CAT');
             set rs = if(rand() < 0.33, 'PUBLISHED', if(rand() < 0.67, 'DELETED', 'FOUND'));
@@ -57,7 +57,7 @@ begin
         end while;
 
     set i = 1;
-    while i <= 500
+    while i <= 50000
         do
             set sp = IF(rand() < 0.5, 'DOG', 'CAT');
             set rs = if(rand() < 0.33, 'PUBLISHED', if(rand() < 0.67, 'DELETED', 'FOUND'));
@@ -70,7 +70,11 @@ begin
                     rs);
             set i = i + 1;
         end while;
-end //
-delimiter //
+end $$
+delimiter $$
 
 call loopinsert();
+# call loopinsert();
+# call loopinsert();
+# call loopinsert();
+# call loopinsert();

--- a/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
+++ b/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
@@ -9,6 +9,7 @@ import com.samcomo.dbz.member.model.repository.MemberRepository;
 import com.samcomo.dbz.report.exception.ReportException;
 import com.samcomo.dbz.report.model.constants.PetType;
 import com.samcomo.dbz.report.model.constants.ReportStatus;
+import com.samcomo.dbz.report.model.dto.CustomSlice;
 import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportDto.Response;
 import com.samcomo.dbz.report.model.dto.ReportList;
@@ -189,9 +190,10 @@ public class ReportServiceTest {
     //given
 
     Pageable pageable = PageRequest.of(1, 10);
-    int cursorId = 0;
-    double latitude = 37.1234;
-    double longitude = 127.1234;
+    double lastLatitude = 37.1111;
+    double lastLongitude = 127.1111;
+    double curLatitude = 37.1234;
+    double curLongitude = 127.1234;
 
     List<Report> reportList = new ArrayList<>();
     for (int i = 1; i <= 10; i++) {
@@ -204,21 +206,23 @@ public class ReportServiceTest {
 
     Slice<Report> reportSlice = new SliceImpl<>(reportList, pageable, true);
     Mockito.when(reportRepository.findAllOrderByDistance(
-            Mockito.anyLong(),
-            Mockito.anyDouble(),
-            Mockito.anyDouble(),
+            Mockito.anyDouble(), Mockito.anyDouble(),
+            Mockito.anyDouble(), Mockito.anyDouble(),
             Mockito.any(Pageable.class)))
         .thenReturn(reportSlice);
 
     //when
-    Slice<ReportList> reportListSlice = reportService.getReportList(0, latitude, longitude, false,
+    CustomSlice<ReportList> reportListSlice = reportService.getReportList(
+        lastLatitude, lastLongitude,
+        curLatitude, lastLongitude,
+        false,
         pageable);
     //then
     int  sliceSize = reportListSlice.getContent().size();
     System.out.println(sliceSize);
     Assertions.assertEquals(1L, reportListSlice.getContent().get(0).getReportId());
     Assertions.assertEquals(10L, reportListSlice.getContent().get(9).getReportId());
-    Assertions.assertTrue(reportListSlice.hasNext());
+    Assertions.assertFalse(reportListSlice.isLast());
     Assertions.assertEquals(pageable.getPageSize(), reportListSlice.getSize());
   }
 
@@ -228,9 +232,10 @@ public class ReportServiceTest {
     //given
 
     Pageable pageable = PageRequest.of(1, 10);
-    int cursorId = 0;
-    double latitude = 37.1234;
-    double longitude = 127.1234;
+    double lastLatitude = 37.1111;
+    double lastLongitude = 127.1111;
+    double curLatitude = 37.1234;
+    double curLongitude = 127.1234;
 
     List<Report> reportList = new ArrayList<>();
     for (int i = 1; i <= 10; i++) {
@@ -243,24 +248,30 @@ public class ReportServiceTest {
 
     Slice<Report> reportSlice = new SliceImpl<>(reportList, pageable, true);
     Mockito.when(reportRepository.findAllInProcessOrderByDistance(
-            Mockito.anyLong(),
-            Mockito.anyDouble(),
-            Mockito.anyDouble(),
+            Mockito.anyDouble(), Mockito.anyDouble(),
+            Mockito.anyDouble(), Mockito.anyDouble(),
             Mockito.any(Pageable.class)))
         .thenReturn(reportSlice);
 
     //when
-    Slice<ReportList> reportListSlice = reportService.getReportList(0, latitude, longitude, true,
+    CustomSlice<ReportList> reportListSlice = reportService.getReportList(
+        lastLatitude, lastLongitude,
+        curLatitude, curLongitude,
+        true,
         pageable);
+
     //then
     int  sliceSize = reportListSlice.getContent().size();
     System.out.println(sliceSize);
     Assertions.assertEquals(1L, reportListSlice.getContent().get(0).getReportId());
     Assertions.assertEquals(10L, reportListSlice.getContent().get(9).getReportId());
-    Assertions.assertTrue(reportListSlice.hasNext());
+    Assertions.assertFalse(reportListSlice.isLast());
     Assertions.assertEquals(pageable.getPageSize(), reportListSlice.getSize());
     Mockito.verify(reportRepository, Mockito.times(0))
-        .findAllOrderByDistance(Mockito.anyLong(), Mockito.anyDouble() ,Mockito.anyDouble() , Mockito.any(Pageable.class));
+        .findAllOrderByDistance(
+            Mockito.anyDouble(), Mockito.anyDouble(),
+            Mockito.anyDouble() ,Mockito.anyDouble(),
+            Mockito.any(Pageable.class));
   }
 
   @Test
@@ -533,10 +544,10 @@ public class ReportServiceTest {
             .build()));
 
     // when
-    Slice<ReportList> reportListSlice = reportService.searchReport("test", false, pageable);
+    CustomSlice<ReportList> reportListSlice = reportService.searchReport("test", false, pageable);
 
     // then
-    Assertions.assertTrue(reportListSlice.hasNext());
+    Assertions.assertFalse(reportListSlice.isLast());
     Assertions.assertEquals(0L, reportListSlice.getContent().get(0).getReportId());
     Assertions.assertEquals(pageable.getPageNumber(), reportListSlice.getPageable().getPageNumber());
   }
@@ -574,10 +585,10 @@ public class ReportServiceTest {
             .build()));
 
     // when
-    Slice<ReportList> reportListSlice = reportService.searchReport("test", true, pageable);
+    CustomSlice<ReportList> reportListSlice = reportService.searchReport("test", true, pageable);
 
     // then
-    Assertions.assertTrue(reportListSlice.hasNext());
+    Assertions.assertFalse(reportListSlice.isLast());
     Assertions.assertEquals(0L, reportListSlice.getContent().get(0).getReportId());
     Assertions.assertEquals(pageable.getPageNumber(), reportListSlice.getPageable().getPageNumber());
     Assertions.assertEquals(reportSlice.getContent().get(0).getReportStatus(), reportListSlice.getContent().get(0).getReportStatus());


### PR DESCRIPTION
## 📌 Issues #27 
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

## ✨ Description

> getReportList() 메소드에서 쿼리 게시글 리스트를 조회할 때 성능이 좋지 못함을 발견
> API 호출시 30초 소요

### Cursor 페이지네이션
기존 offset 방식에서 cursor 방식으로 변경했습니다.
cursor 방식을 사용함으로 기존에 불필요하게 동작 하던 읽기 동작을 하지 않게 되어서 데이터가 많을 수록 눈에 띄는 성능 개선을 확인할 수 있었습니다. 

✅ [노션 정리](https://steadfast-whippet-4c2.notion.site/Query-49713da6a060488b91b50d034bc11fd0)

<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
- [x] 레디스 설정
- [x] getReportList() 메소드에서 사용되는 조회 게시글 리스트 조회 쿼리를 offset 방식에서 cursor 방식으로 수정
- [x] getReportList() 메소드에 대한 테스트 코드 수정

<br/>

## 📚 References
<!-- 참고한 자료가 있다면 적어주세요 -->
[Spring Data Redis Docs](https://docs.spring.io/spring-data/redis/reference/redis.html)
[Cursor based Pagination](https://velog.io/@znftm97/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98Cursor-based-Pagination%EC%9D%B4%EB%9E%80-Querydsl%EB%A1%9C-%EA%B5%AC%ED%98%84%EA%B9%8C%EC%A7%80-so3v8mi2#span-stylecolord9730d7-2-%EC%8B%A4%ED%96%89%EA%B3%84%ED%9A%8D-%ED%99%95%EC%9D%B8---%EC%9D%B8%EB%8D%B1%EC%8A%A4%EA%B0%80-%EC%97%86%EC%9D%84-%EB%95%8Cspan)

<br/>
