### PR TITLE
[Refactor/report] 위/경도 파라미터 타입 변경(primitive -> wrapper), Response 파라미터 추가

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -47,11 +47,8 @@ public class SecurityConfig {
     // mapping
     http
         .authorizeHttpRequests((auth) -> auth
-            .requestMatchers("/member/register").permitAll()
-            .requestMatchers("/report/**", "/aop/**").permitAll()
+            .requestMatchers("/report/", "/aop/").permitAll()
             .requestMatchers("/member/register", "/member/login").permitAll()
-            .requestMatchers("/member/test").hasRole("MEMBER")
-            .requestMatchers("/report/**").permitAll()
             .anyRequest().authenticated());
 
     // session : stateless

--- a/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
+++ b/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
@@ -26,9 +26,6 @@ public enum ErrorCode {
 
   IMAGE_FILE_SIZE_EXCEEDED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 파일 크기 제한을 초과하였습니다."),
 
-  // Report
-
-  IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 저장중 문제가 발생하였습니다."),
 
   // Member
 
@@ -42,10 +39,14 @@ public enum ErrorCode {
 
   // Report
 
+  IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 저장중 문제가 발생하였습니다."),
+
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글 정보를 찾을 수 없습니다."),
-  NOT_SAME_MEMBER(HttpStatus.BAD_REQUEST, "작성자와 유저의 정보가 일치하지 않습니다."),
+
+  NOT_SAME_MEMBER(HttpStatus.BAD_REQUEST, "작성자와 멤버의 정보가 일치하지 않습니다."),
 
   // Redis-Lock
+
   LOCK_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Lock 획득에 실패하였습니다."),
 
   // Chat

--- a/src/main/java/com/samcomo/dbz/global/redis/aop/DistributedLockAop.java
+++ b/src/main/java/com/samcomo/dbz/global/redis/aop/DistributedLockAop.java
@@ -47,14 +47,12 @@ public class DistributedLockAop {
     }catch (InterruptedException e){
       throw new RedissonException(ErrorCode.LOCK_FAIL);
     }finally {
-
-      if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+      try{
         lock.unlock();
         log.info("Lock 제거");
-      }else{
+      }catch (IllegalMonitorStateException e) {
         log.info("이미 Lock을 제거했습니다.");
       }
-
     }
   }
 

--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -1,5 +1,7 @@
 package com.samcomo.dbz.report.controller;
 
+import com.samcomo.dbz.member.jwt.JwtUtil;
+import com.samcomo.dbz.member.model.entity.Member;
 import com.samcomo.dbz.report.model.dto.CustomSlice;
 import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportList;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,21 +33,21 @@ import org.springframework.web.multipart.MultipartFile;
 public class ReportController {
 
   private final ReportService reportService;
+  private final JwtUtil jwtUtil;
 
   @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
   @Operation(summary = "게시글을 이미지와 함께 작성")
   public ResponseEntity<ReportDto.Response> registerReport(
-//      Authentication authentication
+      @AuthenticationPrincipal Member member,
       @RequestPart ReportDto.Form reportForm,
       @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList
   ) {
 
     //TODO: Authentication에서 Member 정보 가져오기
-
+    String email = member.getEmail();
     // Member 도메인코드가 작성이 안돼서 임시로 진행
-    long memberId = 1L;
 
-    ReportDto.Response reportResponse = reportService.uploadReport(memberId, reportForm, imageList);
+    ReportDto.Response reportResponse = reportService.uploadReport(email, reportForm, imageList);
 
     return ResponseEntity.ok(reportResponse);
   }
@@ -52,10 +55,11 @@ public class ReportController {
   @GetMapping("/{reportId}")
   @Operation(summary = "특정 게시글 정보 가져오기")
   public ResponseEntity<ReportDto.Response> getReport(
+      @AuthenticationPrincipal Member member,
       @PathVariable(value = "reportId") long reportId
   ) {
 
-    ReportDto.Response reportResponse = reportService.getReport(reportId);
+    ReportDto.Response reportResponse = reportService.getReport(reportId, member.getEmail());
 
     return ResponseEntity.ok(reportResponse);
   }
@@ -72,7 +76,8 @@ public class ReportController {
   ) {
 
     CustomSlice<ReportList> result =
-        reportService.getReportList(lastLongitude, lastLatitude, curLatitude, curLongitude, showsInProcessOnly, pageable);
+        reportService.getReportList(lastLongitude, lastLatitude, curLatitude, curLongitude,
+            showsInProcessOnly, pageable);
 
     return ResponseEntity.ok(result);
   }
@@ -81,7 +86,7 @@ public class ReportController {
       MediaType.APPLICATION_JSON_VALUE})
   @Operation(summary = "게시글 수정")
   public ResponseEntity<ReportDto.Response> updateReport(
-//      Authentication authentication
+      @AuthenticationPrincipal Member member,
       @PathVariable long reportId,
       @RequestPart ReportDto.Form reportForm,
       @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList
@@ -90,10 +95,10 @@ public class ReportController {
     //TODO: 이미지 수정에대한 처리 리팩토링 필요
 
     //TODO: 유저 정보 가져오기 >> Auth 파트 구현 끝나면 수정 필요
-    long userId = 1L;
+    String email = member.getEmail();
 
     ReportDto.Response reportResponse = reportService.updateReport(reportId, reportForm, imageList,
-        userId);
+        email);
 
     return ResponseEntity.ok(reportResponse);
   }
@@ -101,14 +106,14 @@ public class ReportController {
   @DeleteMapping("/{reportId}")
   @Operation(summary = "게시글 삭제")
   public ResponseEntity<ReportStateDto.Response> deleteReport(
-//      Authentication authentication,
+      @AuthenticationPrincipal Member member,
       @PathVariable long reportId
   ) {
 
     //TODO: 유저 정보 가져오기 >> Auth 파트 구현 끝나면 수정 필요
-    long userId = 1L;
+    String email = member.getEmail();
 
-    ReportStateDto.Response deleteResponse = reportService.deleteReport(userId, reportId);
+    ReportStateDto.Response deleteResponse = reportService.deleteReport(email, reportId);
 
     return ResponseEntity.ok(deleteResponse);
   }
@@ -116,14 +121,14 @@ public class ReportController {
   @PutMapping("/{reportId}/complete")
   @Operation(summary = "게시글 완료 처리")
   public ResponseEntity<ReportStateDto.Response> completeProcess(
-      //      Authentication authentication,
+      @AuthenticationPrincipal Member member,
       @PathVariable long reportId
   ) {
 
     //TODO: 유저 정보 가져오기 >> Auth 파트 구현 끝나면 수정 필요
-    long userId = 1L;
+    String email = member.getEmail();
 
-    ReportStateDto.Response foundResponse = reportService.changeStatusToFound(userId, reportId);
+    ReportStateDto.Response foundResponse = reportService.changeStatusToFound(email, reportId);
     return ResponseEntity.ok(foundResponse);
   }
 
@@ -133,9 +138,10 @@ public class ReportController {
       @RequestParam boolean showsInProgressOnly,
       @RequestParam String object,
       Pageable pageable
-  ){
+  ) {
 
-    CustomSlice<ReportList> result = reportService.searchReport(object, showsInProgressOnly, pageable);
+    CustomSlice<ReportList> result = reportService.searchReport(object, showsInProgressOnly,
+        pageable);
 
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/com/samcomo/dbz/report/model/dto/ReportDto.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/ReportDto.java
@@ -27,8 +27,8 @@ public class ReportDto {
     private String feature;
     private String streetAddress;
     private String roadAddress;
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
   }
 
   @Getter
@@ -37,8 +37,8 @@ public class ReportDto {
   @Builder
   @ToString
   public static class Response{
-    private long reportId;
-    private long memberId;
+    private Long reportId;
+    private Long memberId;
     private String phone;
     private String title;
     private PetType petType;
@@ -49,16 +49,17 @@ public class ReportDto {
     private String petName;
     private String feature;
     private String streetAddress;
+    private boolean isWriter;
     private long views;
     private String roadAddress;
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<ReportImageDto.Response> imageList;
 
     public static Response from(Report report,
-        List<ReportImageDto.Response> reportImageResponseList) {
+        List<ReportImageDto.Response> reportImageResponseList, boolean isWriter) {
       return Response.builder()
           .reportId(report.getId())
           .memberId(report.getMember().getId())
@@ -73,6 +74,7 @@ public class ReportDto {
           .petName(report.getPetName())
           .feature(report.getFeature())
           .streetAddress(report.getStreetAddress())
+          .isWriter(isWriter)
           .roadAddress(report.getRoadAddress())
           .latitude(report.getLatitude())
           .longitude(report.getLongitude())

--- a/src/main/java/com/samcomo/dbz/report/model/dto/ReportList.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/ReportList.java
@@ -27,7 +27,6 @@ public class ReportList {
   private String feature;
   private String streetAddress;
   private String roadAddress;
-  private double lastDistance;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
   private String imageUrl;

--- a/src/main/java/com/samcomo/dbz/report/model/dto/ReportStateDto.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/ReportStateDto.java
@@ -9,7 +9,7 @@ public class ReportStateDto {
   @Getter
   @Builder
   public static class Response{
-    private long reportId;
+    private Long reportId;
     private String status;
 
   }

--- a/src/main/java/com/samcomo/dbz/report/model/entity/Report.java
+++ b/src/main/java/com/samcomo/dbz/report/model/entity/Report.java
@@ -49,8 +49,8 @@ public class Report extends BaseEntity {
   private String feature;
   private String streetAddress;
   private String roadAddress;
-  private double latitude;
-  private double longitude;
+  private Double latitude;
+  private Double longitude;
   private Long views;
   private Boolean showsPhone;
 

--- a/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
+++ b/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
@@ -1,21 +1,20 @@
 package com.samcomo.dbz.report.model.repository;
 
+import com.samcomo.dbz.member.model.entity.Member;
 import com.samcomo.dbz.report.model.constants.ReportStatus;
 import com.samcomo.dbz.report.model.entity.Report;
 import io.lettuce.core.dynamic.annotation.Param;
-import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-  @Lock(value = LockModeType.PESSIMISTIC_WRITE)
-  @Query("select r from Report r where r.id = :id")
-  Optional<Report> findByIdWithPessimistic(Long id);
+
+  Optional<Report> findByIdAndMember(Long id, Member member);
+  Optional<Report> findByIdAndMember_Email(Long id, String email);
 
   @Query(value = "select r "
       + "from Report r "

--- a/src/main/java/com/samcomo/dbz/report/service/ReportService.java
+++ b/src/main/java/com/samcomo/dbz/report/service/ReportService.java
@@ -10,17 +10,17 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface ReportService {
 
-  ReportDto.Response uploadReport(long memberId, ReportDto.Form reportForm, List<MultipartFile> imageList);
+  ReportDto.Response uploadReport(String email, ReportDto.Form reportForm, List<MultipartFile> imageList);
 
-  ReportDto.Response getReport(long reportId);
+  ReportDto.Response getReport(long reportId, String email);
   CustomSlice<ReportList> getReportList(
       double lastLatitude, double lastLongitude, double curLatitude, double curLongitude, boolean showsInProcessOnly, Pageable pageable);
 
-  ReportDto.Response updateReport(long reportId, ReportDto.Form reportForm, List<MultipartFile> imageList, long userId);
+  ReportDto.Response updateReport(long reportId, ReportDto.Form reportForm, List<MultipartFile> imageList, String email);
 
-  Response deleteReport(long userId, long reportId);
+  Response deleteReport(String email, long reportId);
 
-  Response changeStatusToFound(long userId, long reportId);
+  Response changeStatusToFound(String email, long reportId);
 
   CustomSlice<ReportList> searchReport(String object, boolean showsInProgressOnly, Pageable pageable);
 }

--- a/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
+++ b/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
@@ -4,7 +4,6 @@ import com.samcomo.dbz.global.exception.ErrorCode;
 import com.samcomo.dbz.global.s3.constants.ImageCategory;
 import com.samcomo.dbz.global.s3.constants.ImageUploadState;
 import com.samcomo.dbz.global.s3.service.S3Service;
-import com.samcomo.dbz.member.exception.MemberException;
 import com.samcomo.dbz.member.model.entity.Member;
 import com.samcomo.dbz.member.model.repository.MemberRepository;
 import com.samcomo.dbz.report.exception.ReportException;
@@ -60,6 +59,7 @@ public class ReportServiceTest {
   private List<MultipartFile> multipartFileList;
   private ImageUploadState imageUploadState;
   private Report report;
+  private String memberEmail;
 
 
   @BeforeEach
@@ -88,6 +88,8 @@ public class ReportServiceTest {
         .showsPhone(true)
         .views(0L)
         .build();
+
+    memberEmail = "test@gmail.com";
   }
 
   @Test
@@ -101,19 +103,20 @@ public class ReportServiceTest {
 
     Report newReport = Report.from(reportForm, member);
 
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
+    Mockito.when(memberRepository.findByEmail(memberEmail))
         .thenReturn(Optional.of(member));
+
     Mockito.when(s3Service.uploadImageList(multipartFileList, ImageCategory.REPORT))
         .thenReturn(List.of(imageUrl));
 
     newReport.setId(1L);
-    Mockito.when(reportRepository.save(Mockito.any()))
+    Mockito.when(reportRepository.save(Mockito.any(Report.class)))
         .thenReturn(newReport);
-    Mockito.when(reportImageRepository.saveAll(Mockito.any()))
+    Mockito.when(reportImageRepository.saveAll(Mockito.any(List.class)))
         .thenReturn(List.of(reportImage, reportImage));
 
     //when
-    Response response = reportService.uploadReport(1L, reportForm, multipartFileList);
+    Response response = reportService.uploadReport("test@gmail.com", reportForm, multipartFileList);
 
     //then
     Assertions.assertEquals(newReport.getId() ,response.getReportId());
@@ -122,27 +125,13 @@ public class ReportServiceTest {
   }
 
   @Test
-  @DisplayName("게시글 업로드 실패 - 멤버 정보 없음")
-  void uploadReportFail1(){
-    //given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.empty());
-
-    //when
-    Throwable exception = Assertions.assertThrows(MemberException.class,
-        () -> reportService.uploadReport(1L, reportForm, multipartFileList));
-
-    //then
-    Assertions.assertEquals(ErrorCode.MEMBER_NOT_FOUND.getMessage(), exception.getMessage());
-
-  }
-
-  @Test
   @DisplayName("게시글 가져오기 성공")
   void getReportSuccess(){
     //given
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findById(1L))
         .thenReturn(Optional.of(report));
+    Mockito.when(memberRepository.findByEmail(memberEmail))
+        .thenReturn(Optional.of(member));
 
     report.setViews(report.getViews() + 1);
     Mockito.when(reportRepository.save(Mockito.any(Report.class)))
@@ -163,7 +152,7 @@ public class ReportServiceTest {
         ));
 
     //when
-    ReportDto.Response response = reportService.getReport(1L);
+    ReportDto.Response response = reportService.getReport(1L, "test@gmail.com");
 
     //then
     Assertions.assertEquals(report.getId(), response.getReportId());
@@ -176,12 +165,12 @@ public class ReportServiceTest {
   @DisplayName("게시글 가져오기 실패 - 게시글 정보 없음")
   void getReportFail1(){
     //given
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findById(1L))
         .thenReturn(Optional.empty());
 
     //when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.getReport(1L));
+        () -> reportService.getReport(1L, "test@gmail.com"));
 
     //then
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage(), exception.getMessage());
@@ -209,15 +198,15 @@ public class ReportServiceTest {
 
     Slice<Report> reportSlice = new SliceImpl<>(reportList, pageable, true);
     Mockito.when(reportRepository.findAllOrderByDistance(
-            Mockito.anyDouble(), Mockito.anyDouble(),
-            Mockito.anyDouble(), Mockito.anyDouble(),
-            Mockito.any(Pageable.class)))
+            lastLatitude, lastLongitude,
+            curLatitude, curLongitude,
+            pageable))
         .thenReturn(reportSlice);
 
     //when
     CustomSlice<ReportList> reportListSlice = reportService.getReportList(
         lastLatitude, lastLongitude,
-        curLatitude, lastLongitude,
+        curLatitude, curLongitude,
         false,
         pageable);
     //then
@@ -251,9 +240,9 @@ public class ReportServiceTest {
 
     Slice<Report> reportSlice = new SliceImpl<>(reportList, pageable, true);
     Mockito.when(reportRepository.findAllInProcessOrderByDistance(
-            Mockito.anyDouble(), Mockito.anyDouble(),
-            Mockito.anyDouble(), Mockito.anyDouble(),
-            Mockito.any(Pageable.class)))
+            lastLatitude, lastLongitude,
+            curLatitude, curLongitude,
+            pageable))
         .thenReturn(reportSlice);
 
     //when
@@ -287,17 +276,19 @@ public class ReportServiceTest {
             .imageUrl("http://testUpload/test.png")
         .build());
 
-    ReportImage reportImage = ReportImage.builder()
+    ReportImage reportImage1 = ReportImage.builder()
+        .id(1L)
+        .imageUrl(imageUploadState.getImageUrl())
+        .build();
+    ReportImage reportImage2 = ReportImage.builder()
+        .id(2L)
         .imageUrl(imageUploadState.getImageUrl())
         .build();
     String imageUrl = imageUploadState.getImageUrl();
 
-
-    Mockito.when(memberRepository.findById(1L))
-        .thenReturn(Optional.of(member));
-    Mockito.when(reportRepository.findById(1L))
+    Mockito.when(reportRepository.findByIdAndMember_Email(1L, "test@gmail.com"))
         .thenReturn(Optional.of(report));
-    Mockito.when(reportImageRepository.findAllByReport(Mockito.any(Report.class)))
+    Mockito.when(reportImageRepository.findAllByReport(report))
         .thenReturn(reportImageList);
 
     Mockito.when(s3Service.uploadImageList(multipartFileList, ImageCategory.REPORT))
@@ -306,13 +297,13 @@ public class ReportServiceTest {
 
     Mockito.when(reportRepository.save(report))
         .thenReturn(report);
-    Mockito.when(reportImageRepository.saveAll(Mockito.any()))
-        .thenReturn(List.of(reportImage, reportImage));
+    Mockito.when(reportImageRepository.saveAll(Mockito.any(List.class)))
+        .thenReturn(List.of(reportImage1, reportImage2));
 
     ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
 
     //when
-    Response response = reportService.updateReport(1L, reportForm, multipartFileList, 1L);
+    Response response = reportService.updateReport(1L, reportForm, multipartFileList, "test@gmail.com");
 
     //then
     Mockito.verify(s3Service).deleteFile(fileNameCaptor.capture());
@@ -323,51 +314,17 @@ public class ReportServiceTest {
   }
 
   @Test
-  @DisplayName("게시글 수정 실패 - 멤버 정보 없음")
+  @DisplayName("게시글 수정 실패 - 게시글 정보 없음")
   void updateReportFail1(){
     //given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.empty());
-    //when
-    Throwable exception = Assertions.assertThrows(MemberException.class,
-        ()-> reportService.updateReport(1L, reportForm, multipartFileList, 1L));
-
-    //then
-    Assertions.assertEquals(ErrorCode.MEMBER_NOT_FOUND.getMessage(), exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("게시글 수정 실패 - 게시글 정보 없음")
-  void updateReportFail2(){
-    //given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findByIdAndMember_Email(1L, "test@gmail.com"))
         .thenReturn(Optional.empty());
     //when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        ()-> reportService.updateReport(1L, reportForm, multipartFileList, 1L));
+        ()-> reportService.updateReport(1L, reportForm, multipartFileList, "test@gmail.com"));
 
     //then
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage(), exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("게시글 수정 실패 - 게시글 작성자와 수정 유청자가 다름")
-  void updateReportFail3(){
-    //given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    report.setMember(Member.builder().id(2L).build());
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(report));
-
-    //when
-    Throwable exception = Assertions.assertThrows(ReportException.class,
-        ()-> reportService.updateReport(1L, reportForm, multipartFileList, 1L));
-
-    //then
-    Assertions.assertEquals(ErrorCode.NOT_SAME_MEMBER.getMessage(), exception.getMessage());
   }
 
   @Test
@@ -379,16 +336,14 @@ public class ReportServiceTest {
         .imageUrl("http://testUpload/test.png")
         .build());
 
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findByIdAndMember_Email(1L, "test@gmail.com"))
         .thenReturn(Optional.of(report));
-    Mockito.when(reportImageRepository.findAllByReport(Mockito.any(Report.class)))
+    Mockito.when(reportImageRepository.findAllByReport(report))
         .thenReturn(reportImageList);
 
     ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
     // when
-    ReportStateDto.Response response = reportService.deleteReport(1L, 1L);
+    ReportStateDto.Response response = reportService.deleteReport("test@gmail.com", 1L);
 
     // then
     Mockito.verify(s3Service).deleteFile(fileNameCaptor.capture());
@@ -400,70 +355,32 @@ public class ReportServiceTest {
   }
 
   @Test
-  @DisplayName("게시글 삭제 실패 - 멤버 정보 없음")
-  void deleteReportFail1(){
-    // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.empty());
-
-    // when
-    Throwable exception = Assertions.assertThrows(MemberException.class,
-        () -> reportService.deleteReport(1L, 1L));
-
-    // then
-
-    Assertions.assertEquals(ErrorCode.MEMBER_NOT_FOUND.getMessage() ,exception.getMessage());
-  }
-
-  @Test
   @DisplayName("게시글 삭제 실패 - 게시글 정보 없음")
   void deleteReportFail2(){
     // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findByIdAndMember_Email(1L, "test@gmail.com"))
         .thenReturn(Optional.empty());
 
     // when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.deleteReport(1L, 1L));
+        () -> reportService.deleteReport("test@gmail.com", 1L));
 
     // then
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage() ,exception.getMessage());
   }
 
   @Test
-  @DisplayName("게시글 삭제 실패 - 게시글 작성자와 삭제 요청자 불일치")
-  void deleteReportFail3(){
-    // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    report.setMember(Member.builder().id(2L).build());
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(report));
-
-    // when
-    Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.deleteReport(2L, 1L));
-
-    // then
-    Assertions.assertEquals(ErrorCode.NOT_SAME_MEMBER.getMessage() ,exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("게시글 상태 '찾음'으로 변경 성공")
+  @DisplayName("게시글 상태 '찾음' 으로 변경 성공")
   void changeStatusToFoundSuccess(){
     // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findByIdAndMember_Email(1L, "test@gmail.com"))
         .thenReturn(Optional.of(report));
     report.setReportStatus(ReportStatus.FOUND);
-    Mockito.when(reportRepository.save(Mockito.any(Report.class)))
+    Mockito.when(reportRepository.save(report))
         .thenReturn(report);
 
     // when
-    ReportStateDto.Response response = reportService.changeStatusToFound(1L, 1L);
+    ReportStateDto.Response response = reportService.changeStatusToFound("test@gmail.com", 1L);
 
     // then
     Assertions.assertEquals(report.getId(), response.getReportId());
@@ -471,56 +388,19 @@ public class ReportServiceTest {
   }
 
   @Test
-  @DisplayName("게시글 상태 '찾음'으로 변경 실패 - 멤버 정보 없음")
-  void changeStatusToFoundFail1(){
-    // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.empty());
-
-    // when
-    Throwable exception = Assertions.assertThrows(MemberException.class,
-        () -> reportService.changeStatusToFound(1L, 1L));
-
-    // then
-
-    Assertions.assertEquals(ErrorCode.MEMBER_NOT_FOUND.getMessage(), exception.getMessage());
-  }
-
-  @Test
   @DisplayName("게시글 상태 '찾음'으로 변경 실패 - 게시글 정보 없음")
   void changeStatusToFoundFail2(){
     // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
+    Mockito.when(reportRepository.findByIdAndMember_Email(1L, "test@gmail.com"))
         .thenReturn(Optional.empty());
 
     // when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.changeStatusToFound(1L, 1L));
+        () -> reportService.changeStatusToFound("test@gmail.com", 1L));
 
     // then
 
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage(), exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("게시글 상태 '찾음'으로 변경 실패 - 상태 변경 요청자와 게시글 작성자 불일치")
-  void changeStatusToFoundFail3(){
-    // given
-    Mockito.when(memberRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(member));
-    report.setMember(Member.builder().id(2L).build());
-    Mockito.when(reportRepository.findById(Mockito.anyLong()))
-        .thenReturn(Optional.of(report));
-
-    // when
-    Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.changeStatusToFound(1L, 1L));
-
-    // then
-
-    Assertions.assertEquals(ErrorCode.NOT_SAME_MEMBER.getMessage(), exception.getMessage());
   }
 
   @Test
@@ -561,6 +441,7 @@ public class ReportServiceTest {
   void searchReportSuccess2(){
     //given
     Pageable pageable = PageRequest.of(1, 10);
+    String object = "test";
 
     List<Report> reportList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
@@ -576,11 +457,11 @@ public class ReportServiceTest {
 
     Mockito.when(reportRepository
         .findAllByTitleContainsOrPetNameContainsOrSpeciesContainsAndReportStatus(
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.any(ReportStatus.class),
-            Mockito.any(Pageable.class)
+            object,
+            object,
+            object,
+            ReportStatus.PUBLISHED,
+            pageable
         ))
         .thenReturn(reportSlice);
     Mockito.when(reportImageRepository.findFirstByReport(Mockito.any(Report.class)))

--- a/src/test/java/com/samcomo/dbz/report/service/ReportViewTest.java
+++ b/src/test/java/com/samcomo/dbz/report/service/ReportViewTest.java
@@ -38,7 +38,7 @@ public class ReportViewTest {
     for (int i = 0; i < threadCount; i++) {
       executorService.submit(() -> {
         try {
-          reportService.getReport(1L);
+          reportService.getReport(1L, "test@gmail.com");
         } finally {
           latch.countDown();
         }


### PR DESCRIPTION
## 📌 Issues <!-- #issue number -->

<br/>

## ✨ Description

- 위/경도 값에 primitive type을 사용하면 0.0이 기본으로 설정 되는데, 이렇게 되면 거리를 계산할 때 정확한 값이 나오지 않으므로 각각 null 값으로 받아 처리하기위해 수정했습니다.
- 프론트에서 게시글의 디테일한 정보를 주는 API 를 호출 할 때 요청자가 작성자와 동일한지를 알 수 있도록 ReportDto.Response에 isWriter 를 추가하여 boolean 타입으로 확인할 수 있도록 수정했습니다.
> 프론트에서 작성자일경우와 작성자가 아닐 경우 UI가 다르게 구성되어 판별할 수 있는 값이 필요하다고 요청이 들어와 수정했습니다.


