### PR TITLE
[Hotfix/Report] 게시글 삭제 불가 해결

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/s3/service/S3Service.java
+++ b/src/main/java/com/samcomo/dbz/global/s3/service/S3Service.java
@@ -11,7 +11,6 @@ import com.samcomo.dbz.global.exception.ErrorCode;
 import com.samcomo.dbz.global.s3.constants.ImageCategory;
 import com.samcomo.dbz.global.s3.constants.ImageUploadState;
 import com.samcomo.dbz.global.s3.exception.S3Exception;
-import com.samcomo.dbz.report.model.entity.ReportImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,16 +100,6 @@ public class S3Service {
     String extension = filename.substring(idx + 1);
     return "image/" + extension;
   }
-
-  private void deleteUploadedReportImageList(List<ReportImage> imageList){
-    for (ReportImage reportImage : imageList){
-      String imageUrl = reportImage.getImageUrl();
-      int idx = imageUrl.lastIndexOf("/");
-      String fileName = imageUrl.substring(idx + 1);
-      deleteFile(fileName);
-    }
-  }
-
   private void deleteUploadedImageList(List<String> imageUrlList){
     for (String imageUrl : imageUrlList){
       int idx = imageUrl.lastIndexOf("/");

--- a/src/main/java/com/samcomo/dbz/report/model/entity/ReportImage.java
+++ b/src/main/java/com/samcomo/dbz/report/model/entity/ReportImage.java
@@ -36,8 +36,4 @@ public class ReportImage extends BaseEntity {
   @JoinColumn
   private Report report;
 
-  public ReportImage(String imageUrl, Report report){
-    this.imageUrl = imageUrl;
-    this.report = report;
-  }
 }

--- a/src/main/java/com/samcomo/dbz/report/model/repository/ReportImageRepository.java
+++ b/src/main/java/com/samcomo/dbz/report/model/repository/ReportImageRepository.java
@@ -11,6 +11,4 @@ public interface ReportImageRepository extends JpaRepository<ReportImage, Long> 
   List<ReportImage> findAllByReport(Report report);
 
   Optional<ReportImage> findFirstByReport(Report report);
-
-  List<ReportImage> findAllByReportIn(List<Report> reportList);
 }

--- a/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
@@ -185,6 +185,7 @@ public class ReportServiceImpl implements ReportService {
       s3Service.deleteFile(url.substring(idx + 1));
     }
 
+    reportImageRepository.deleteAll(reportImageList);
     reportRepository.delete(report);
 
     return ReportStateDto.Response.builder()


### PR DESCRIPTION
## 📌 Issues <!-- #issue number -->
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

ReportImage에 대한 데이터를 먼저 삭제해야 Report 데이터를 삭제할 수 있습니다. 
Report 의 ID 값을 ReportImage가 관리하고 있기 때문에 선행되어야 할 동작입니다.
이전 코드에서는 ReportImage 삭제를 하는 코드가 수정하면서 지워져서 삭제가 불가능했기 때문에 삭제 메소드를 추가했습니다.

<수정 후>
RepotImage삭제 -> Report 삭제
