### PR TITLE
[Refactor/member] jwt 토큰 페이로드 정보 변경

### DIFF
--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtUtil {
 
-  private static final String EMAIL_KEY = "email";
+  private static final String ID_KEY = "id";
   private static final String ROLE_KEY = "role";
 
   private final SecretKey secretKey;
@@ -29,10 +29,10 @@ public class JwtUtil {
         .getSubject();
   }
 
-  public String getEmail(String token) {
+  public String getId(String token) {
 
     return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-        .get(EMAIL_KEY, String.class);
+        .get(ID_KEY, String.class);
   }
 
   public String getRole(String token) {
@@ -47,11 +47,11 @@ public class JwtUtil {
         .getExpiration().before(new Date());
   }
 
-  public String createToken(TokenType tokenType, String email, String role, Long expiredMs) {
+  public String createToken(TokenType tokenType, String id, String role, Long expiredMs) {
 
     return Jwts.builder()
         .subject(tokenType.getKey())
-        .claim(EMAIL_KEY, email)
+        .claim(ID_KEY, id)
         .claim(ROLE_KEY, role)
         .issuedAt(new Date(System.currentTimeMillis()))
         .expiration(new Date(System.currentTimeMillis() + expiredMs))

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/JwtFilter.java
@@ -36,12 +36,12 @@ public class JwtFilter extends OncePerRequestFilter {
       return;
     }
 
-    String email = jwtUtil.getEmail(accessToken);
+    Long memberId = Long.valueOf(jwtUtil.getId(accessToken));
     MemberRole role = MemberRole.get(jwtUtil.getRole(accessToken))
         .orElseThrow(() -> new MemberException(INVALID_SESSION));
 
     Member member = Member.builder()
-        .email(email)
+        .id(memberId)
         .role(role)
         .build();
 

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/LoginFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/LoginFilter.java
@@ -3,8 +3,8 @@ package com.samcomo.dbz.member.jwt.filter;
 import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
 import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
 
-import com.samcomo.dbz.member.model.dto.MemberDetails;
 import com.samcomo.dbz.member.jwt.JwtUtil;
+import com.samcomo.dbz.member.model.dto.MemberDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -71,16 +71,16 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
       throws IOException, ServletException {
 
     MemberDetails memberDetails = (MemberDetails) authResult.getPrincipal();
-    String email = memberDetails.getEmail();
+    String id = String.valueOf(memberDetails.getId());
 
     Iterator<? extends GrantedAuthority> iterator = authResult.getAuthorities().iterator();
     GrantedAuthority auth = iterator.next();
     String role = auth.getAuthority();
 
     String accessToken = jwtUtil.createToken(
-        ACCESS_TOKEN, email, role, EXPIRATION_ACCESS_TOKEN);
+        ACCESS_TOKEN, id, role, EXPIRATION_ACCESS_TOKEN);
     String refreshToken = jwtUtil.createToken(
-        REFRESH_TOKEN, email, role, EXPIRATION_REFRESH_TOKEN);
+        REFRESH_TOKEN, id, role, EXPIRATION_REFRESH_TOKEN);
 
     response.setHeader(ACCESS_TOKEN.getKey(), accessToken);
     response.addCookie(createCookie(REFRESH_TOKEN.getKey(), refreshToken));

--- a/src/main/java/com/samcomo/dbz/member/model/dto/MemberDetails.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/MemberDetails.java
@@ -37,7 +37,7 @@ public class MemberDetails implements UserDetails {
     return member.getEmail();
   }
 
-  public Long getId() {
+  public long getId() {
     return member.getId();
   }
 

--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -1,6 +1,6 @@
 package com.samcomo.dbz.report.controller;
 
-import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.member.model.dto.MemberDetails;
 import com.samcomo.dbz.member.service.impl.MemberServiceImpl;
 import com.samcomo.dbz.report.model.dto.CustomSlice;
 import com.samcomo.dbz.report.model.dto.ReportDto;
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,15 +38,13 @@ public class ReportController {
   @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
   @Operation(summary = "게시글을 이미지와 함께 작성")
   public ResponseEntity<ReportDto.Response> registerReport(
-      Authentication authentication,
+      @AuthenticationPrincipal MemberDetails details,
       @RequestPart ReportDto.Form reportForm,
       @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList
   ) {
 
-    // TODO(Goo) : db 조회 안 하고 가져오는 방법 고민
-    Member member = memberService.getMemberByAuthentication(authentication);
-
-    ReportDto.Response reportResponse = reportService.uploadReport(member, reportForm, imageList);
+    ReportDto.Response reportResponse =
+        reportService.uploadReport(details.getId(), reportForm, imageList);
 
     return ResponseEntity.ok(reportResponse);
   }
@@ -54,13 +52,11 @@ public class ReportController {
   @GetMapping("/{reportId}")
   @Operation(summary = "특정 게시글 정보 가져오기")
   public ResponseEntity<ReportDto.Response> getReport(
-      Authentication authentication,
+      @AuthenticationPrincipal MemberDetails details,
       @PathVariable(value = "reportId") long reportId
   ) {
 
-    Member member = memberService.getMemberByAuthentication(authentication);
-
-    ReportDto.Response reportResponse = reportService.getReport(reportId, member);
+    ReportDto.Response reportResponse = reportService.getReport(reportId, details.getId());
 
     return ResponseEntity.ok(reportResponse);
   }
@@ -87,16 +83,14 @@ public class ReportController {
       MediaType.APPLICATION_JSON_VALUE})
   @Operation(summary = "게시글 수정")
   public ResponseEntity<ReportDto.Response> updateReport(
-      Authentication authentication,
+      @AuthenticationPrincipal MemberDetails details,
       @PathVariable long reportId,
       @RequestPart ReportDto.Form reportForm,
       @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList
   ) {
 
-    Member member = memberService.getMemberByAuthentication(authentication);
-
-    ReportDto.Response reportResponse = reportService.updateReport(reportId, reportForm, imageList,
-        member);
+    ReportDto.Response reportResponse =
+        reportService.updateReport(reportId, details.getId(), reportForm, imageList);
 
     return ResponseEntity.ok(reportResponse);
   }
@@ -104,13 +98,11 @@ public class ReportController {
   @DeleteMapping("/{reportId}")
   @Operation(summary = "게시글 삭제")
   public ResponseEntity<ReportStateDto.Response> deleteReport(
-      Authentication authentication,
+      @AuthenticationPrincipal MemberDetails details,
       @PathVariable long reportId
   ) {
 
-    Member member = memberService.getMemberByAuthentication(authentication);
-
-    ReportStateDto.Response deleteResponse = reportService.deleteReport(member, reportId);
+    ReportStateDto.Response deleteResponse = reportService.deleteReport(details.getId(), reportId);
 
     return ResponseEntity.ok(deleteResponse);
   }
@@ -118,13 +110,12 @@ public class ReportController {
   @PutMapping("/{reportId}/complete")
   @Operation(summary = "게시글 완료 처리")
   public ResponseEntity<ReportStateDto.Response> completeProcess(
-      Authentication authentication,
+      @AuthenticationPrincipal MemberDetails details,
       @PathVariable long reportId
   ) {
 
-    Member member = memberService.getMemberByAuthentication(authentication);
-
-    ReportStateDto.Response foundResponse = reportService.changeStatusToFound(member, reportId);
+    ReportStateDto.Response foundResponse =
+        reportService.changeStatusToFound(details.getId(), reportId);
 
     return ResponseEntity.ok(foundResponse);
   }

--- a/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
+++ b/src/main/java/com/samcomo/dbz/report/model/repository/ReportRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-  Optional<Report> findByIdAndMember(Long id, Member member);
+  Optional<Report> findByIdAndMember_Id(Long id, Long memberId);
 
   @Query(value = "select r "
       + "from Report r "

--- a/src/main/java/com/samcomo/dbz/report/service/ReportService.java
+++ b/src/main/java/com/samcomo/dbz/report/service/ReportService.java
@@ -11,19 +11,18 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface ReportService {
 
-  ReportDto.Response uploadReport(Member member, ReportDto.Form reportForm,
-      List<MultipartFile> imageList);
+  ReportDto.Response uploadReport(long memberId, ReportDto.Form reportForm, List<MultipartFile> imageList);
 
-  ReportDto.Response getReport(long reportId, Member member);
+  ReportDto.Response getReport(long reportId, long memberId);
+
   CustomSlice<ReportSummaryDto> getReportList(
       double lastLatitude, double lastLongitude, double curLatitude, double curLongitude, boolean showsInProcessOnly, Pageable pageable);
 
-  ReportDto.Response updateReport(long reportId, ReportDto.Form reportForm,
-      List<MultipartFile> imageList, Member member);
+  ReportDto.Response updateReport(long reportId, long memberId, ReportDto.Form reportForm, List<MultipartFile> imageList);
 
-  Response deleteReport(Member member, long reportId);
+  Response deleteReport(long reportId, long memberId);
 
-  Response changeStatusToFound(Member member, long reportId);
+  Response changeStatusToFound(long reportId, long memberId);
 
   CustomSlice<ReportSummaryDto> searchReport(String object, boolean showsInProgressOnly, Pageable pageable);
 }

--- a/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
@@ -1,11 +1,15 @@
 package com.samcomo.dbz.report.service.impl;
 
+import static com.samcomo.dbz.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+
 import com.samcomo.dbz.global.exception.ErrorCode;
 import com.samcomo.dbz.global.redis.LockType;
 import com.samcomo.dbz.global.redis.aop.DistributedLock;
 import com.samcomo.dbz.global.s3.constants.ImageCategory;
 import com.samcomo.dbz.global.s3.service.S3Service;
+import com.samcomo.dbz.member.exception.MemberException;
 import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.member.model.repository.MemberRepository;
 import com.samcomo.dbz.report.exception.ReportException;
 import com.samcomo.dbz.report.model.constants.ReportStatus;
 import com.samcomo.dbz.report.model.dto.CustomPageable;
@@ -21,6 +25,7 @@ import com.samcomo.dbz.report.model.repository.ReportRepository;
 import com.samcomo.dbz.report.service.ReportService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,12 +41,17 @@ public class ReportServiceImpl implements ReportService {
 
   private final ReportRepository reportRepository;
   private final ReportImageRepository reportImageRepository;
+  private final MemberRepository memberRepository;
   private final S3Service s3Service;
 
   @Override
   public ReportDto.Response uploadReport(
-      Member member, ReportDto.Form reportForm, List<MultipartFile> multipartFileList
+      long memberId, ReportDto.Form reportForm, List<MultipartFile> multipartFileList
   ) {
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
     // S3 이미지 저장
     List<String> imageUrlList = s3Service.uploadImageList(multipartFileList, ImageCategory.REPORT);
 
@@ -68,12 +78,12 @@ public class ReportServiceImpl implements ReportService {
 
   @Override
   @DistributedLock(lockType = LockType.REPORT ,key = "redisLock", waitTime = 3L, leaseTime = 5L)
-  public ReportDto.Response getReport(long reportId, Member member) {
+  public ReportDto.Response getReport(long reportId, long memberId) {
 
     Report report = reportRepository.findById(reportId)
         .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
 
-    boolean isWriter = report.getMember().equals(member);
+    boolean isWriter = report.getMember().getId() == memberId;
 
     log.info("현재 조회수 : {}", report.getViews());
 
@@ -121,10 +131,10 @@ public class ReportServiceImpl implements ReportService {
 
   @Override
   public ReportDto.Response updateReport(
-      long reportId, ReportDto.Form reportForm, List<MultipartFile> multipartFileList, Member member
+      long reportId, long memberId, ReportDto.Form reportForm, List<MultipartFile> multipartFileList
   ) {
 
-    Report report = reportRepository.findByIdAndMember(reportId, member)
+    Report report = reportRepository.findByIdAndMember_Id(reportId, memberId)
         .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
 
     report.setTitle(reportForm.getTitle());
@@ -144,7 +154,6 @@ public class ReportServiceImpl implements ReportService {
       String url = reportImage.getImageUrl();
       int idx = url.lastIndexOf("/");
 
-      // TODO : AWS_SDK_ERROR (테스트용 이미지 파일명 때문인 듯 함.)
       s3Service.deleteFile(url.substring(idx + 1));
     }
 
@@ -171,9 +180,9 @@ public class ReportServiceImpl implements ReportService {
   }
 
   @Override
-  public ReportStateDto.Response deleteReport(Member member, long reportId) {
+  public ReportStateDto.Response deleteReport(long reportId, long memberId) {
 
-    Report report = reportRepository.findByIdAndMember(reportId, member)
+    Report report = reportRepository.findByIdAndMember_Id(reportId, memberId)
         .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
 
     List<ReportImage> reportImageList = reportImageRepository.findAllByReport(report);
@@ -181,7 +190,6 @@ public class ReportServiceImpl implements ReportService {
       String url = reportImage.getImageUrl();
       int idx = url.lastIndexOf("/");
 
-      // TODO : AWS_SDK_ERROR (테스트용 이미지 파일명 때문인 듯 함.)
       s3Service.deleteFile(url.substring(idx + 1));
     }
 
@@ -195,9 +203,9 @@ public class ReportServiceImpl implements ReportService {
   }
 
   @Override
-  public ReportStateDto.Response changeStatusToFound(Member member, long reportId) {
+  public ReportStateDto.Response changeStatusToFound(long reportId, long memberId) {
 
-    Report report = reportRepository.findByIdAndMember(reportId, member)
+    Report report = reportRepository.findByIdAndMember_Id(reportId, memberId)
         .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
 
     report.setReportStatus(ReportStatus.FOUND);

--- a/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
+++ b/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
@@ -5,6 +5,7 @@ import com.samcomo.dbz.global.s3.constants.ImageCategory;
 import com.samcomo.dbz.global.s3.constants.ImageUploadState;
 import com.samcomo.dbz.global.s3.service.S3Service;
 import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.member.model.repository.MemberRepository;
 import com.samcomo.dbz.report.exception.ReportException;
 import com.samcomo.dbz.report.model.constants.PetType;
 import com.samcomo.dbz.report.model.constants.ReportStatus;
@@ -44,6 +45,8 @@ public class ReportServiceTest {
 
   @Mock
   private ReportRepository reportRepository;
+  @Mock
+  private MemberRepository memberRepository;
   @Mock
   private ReportImageRepository reportImageRepository;
   @Mock
@@ -95,6 +98,9 @@ public class ReportServiceTest {
 
     Report newReport = Report.from(reportForm, member);
 
+    Mockito.when(memberRepository.findById(member.getId()))
+        .thenReturn(Optional.of(member));
+
     Mockito.when(s3Service.uploadImageList(multipartFileList, ImageCategory.REPORT))
         .thenReturn(List.of(imageUrl));
 
@@ -105,7 +111,7 @@ public class ReportServiceTest {
         .thenReturn(List.of(reportImage, reportImage));
 
     //when
-    Response response = reportService.uploadReport(member, reportForm, multipartFileList);
+    Response response = reportService.uploadReport(member.getId(), reportForm, multipartFileList);
 
     //then
     Assertions.assertEquals(newReport.getId() ,response.getReportId());
@@ -139,7 +145,7 @@ public class ReportServiceTest {
         ));
 
     //when
-    ReportDto.Response response = reportService.getReport(1L, member);
+    ReportDto.Response response = reportService.getReport(1L, member.getId());
 
     //then
     Assertions.assertEquals(report.getId(), response.getReportId());
@@ -157,7 +163,7 @@ public class ReportServiceTest {
 
     //when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.getReport(1L, member));
+        () -> reportService.getReport(1L, member.getId()));
 
     //then
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage(), exception.getMessage());
@@ -275,7 +281,7 @@ public class ReportServiceTest {
         .build();
     String imageUrl = imageUploadState.getImageUrl();
 
-    Mockito.when(reportRepository.findByIdAndMember(1L, member))
+    Mockito.when(reportRepository.findByIdAndMember_Id(1L, member.getId()))
         .thenReturn(Optional.of(report));
     Mockito.when(reportImageRepository.findAllByReport(report))
         .thenReturn(reportImageList);
@@ -292,7 +298,8 @@ public class ReportServiceTest {
     ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
 
     //when
-    Response response = reportService.updateReport(1L, reportForm, multipartFileList, member);
+    Response response =
+        reportService.updateReport(1L, member.getId(), reportForm, multipartFileList);
 
     //then
     Mockito.verify(s3Service).deleteFile(fileNameCaptor.capture());
@@ -306,11 +313,11 @@ public class ReportServiceTest {
   @DisplayName("게시글 수정 실패 - 게시글 정보 없음")
   void updateReportFail1(){
     //given
-    Mockito.when(reportRepository.findByIdAndMember(1L, member))
+    Mockito.when(reportRepository.findByIdAndMember_Id(1L, member.getId()))
         .thenReturn(Optional.empty());
     //when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        ()-> reportService.updateReport(1L, reportForm, multipartFileList, member));
+        ()-> reportService.updateReport(1L, member.getId(), reportForm, multipartFileList));
 
     //then
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage(), exception.getMessage());
@@ -325,14 +332,14 @@ public class ReportServiceTest {
         .imageUrl("http://testUpload/test.png")
         .build());
 
-    Mockito.when(reportRepository.findByIdAndMember(1L, member))
+    Mockito.when(reportRepository.findByIdAndMember_Id(1L, member.getId()))
         .thenReturn(Optional.of(report));
     Mockito.when(reportImageRepository.findAllByReport(report))
         .thenReturn(reportImageList);
 
     ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
     // when
-    ReportStateDto.Response response = reportService.deleteReport(member, 1L);
+    ReportStateDto.Response response = reportService.deleteReport(1L, member.getId());
 
     // then
     Mockito.verify(s3Service).deleteFile(fileNameCaptor.capture());
@@ -347,12 +354,12 @@ public class ReportServiceTest {
   @DisplayName("게시글 삭제 실패 - 게시글 정보 없음")
   void deleteReportFail2(){
     // given
-    Mockito.when(reportRepository.findByIdAndMember(1L, member))
+    Mockito.when(reportRepository.findByIdAndMember_Id(1L, member.getId()))
         .thenReturn(Optional.empty());
 
     // when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.deleteReport(member, 1L));
+        () -> reportService.deleteReport(1L, member.getId()));
 
     // then
     Assertions.assertEquals(ErrorCode.REPORT_NOT_FOUND.getMessage() ,exception.getMessage());
@@ -362,14 +369,14 @@ public class ReportServiceTest {
   @DisplayName("게시글 상태 '찾음' 으로 변경 성공")
   void changeStatusToFoundSuccess(){
     // given
-    Mockito.when(reportRepository.findByIdAndMember(1L, member))
+    Mockito.when(reportRepository.findByIdAndMember_Id(1L, member.getId()))
         .thenReturn(Optional.of(report));
     report.setReportStatus(ReportStatus.FOUND);
     Mockito.when(reportRepository.save(report))
         .thenReturn(report);
 
     // when
-    ReportStateDto.Response response = reportService.changeStatusToFound(member, 1L);
+    ReportStateDto.Response response = reportService.changeStatusToFound(1L, member.getId());
 
     // then
     Assertions.assertEquals(report.getId(), response.getReportId());
@@ -380,12 +387,12 @@ public class ReportServiceTest {
   @DisplayName("게시글 상태 '찾음'으로 변경 실패 - 게시글 정보 없음")
   void changeStatusToFoundFail2(){
     // given
-    Mockito.when(reportRepository.findByIdAndMember(1L, member))
+    Mockito.when(reportRepository.findByIdAndMember_Id(1L, member.getId()))
         .thenReturn(Optional.empty());
 
     // when
     Throwable exception = Assertions.assertThrows(ReportException.class,
-        () -> reportService.changeStatusToFound(member, 1L));
+        () -> reportService.changeStatusToFound(1L, member.getId()));
 
     // then
 

--- a/src/test/java/com/samcomo/dbz/report/service/ReportViewTest.java
+++ b/src/test/java/com/samcomo/dbz/report/service/ReportViewTest.java
@@ -50,7 +50,7 @@ public class ReportViewTest {
     for (int i = 0; i < threadCount; i++) {
       executorService.submit(() -> {
         try {
-          reportService.getReport(1L, member);
+          reportService.getReport(1L, member.getId());
         } finally {
           latch.countDown();
         }


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
- [x] Test 완료 여부

기존 jwt 에 담기는 정보 중 식별키로 이용한 컬럼은 `email` 이었습니다.

String 값인 이메일 정보로 DB 를 조회하는 것보다 Long 값인 memberId 로 조회하는 것이 효율적이라고 판단하였습니다.

따라서 email 을 페이로드에서 제외하고, id 값을 추가하였습니다.

<br/>

### 구현 방법

- JwtUtil.java

```java
public String createToken(TokenType tokenType, String id, String role, Long expiredMs) {

  return Jwts.builder()
      .subject(tokenType.getKey())
      .claim(ID_KEY, id)
      .claim(ROLE_KEY, role)
      .issuedAt(new Date(System.currentTimeMillis()))
      .expiration(new Date(System.currentTimeMillis() + expiredMs))
      .signWith(secretKey)
      .compact();
}
```

로그인 성공 시 jwt 를 생성하는 메서드가 호출되며 이 정보는 헤더에 담겨 반환됩니다.
회원은 앞으로 api 를 요청할 때마다 이 jwt 를 가지고 JwtFilter 에서 인가 과정을 거칩니다.

<br/>

- JwtFilter.java

```java
@Override
protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

  // 헤더에서 토큰 가져오기
  String accessToken = request.getHeader(ACCESS_TOKEN.getKey());

  // 토큰 유효성 검사(만료기간 지났는지 등)
  if (!validateAccessToken(request, response, filterChain, accessToken)) {
    return;
  }

  // jwt 복호화를 통해 id 가져오기
  Long memberId = Long.valueOf(jwtUtil.getId(accessToken));

  // jwt 복호화를 통해 권한정보 가져오기
  MemberRole role = MemberRole.get(jwtUtil.getRole(accessToken))
      .orElseThrow(() -> new MemberException(INVALID_SESSION));

  // MemberDetails 생성 용 Member 객체 생성 시 id 값 담기
  Member member = Member.builder()
      .id(memberId)
      .role(role)
      .build();

  // 세션에 담길 MemberDetails 객체 생성
  MemberDetails memberDetails = new MemberDetails(member);

  Authentication authToken = new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());

  // 세션에 저장
  SecurityContextHolder.getContext().setAuthentication(authToken);

  filterChain.doFilter(request, response);
}
```

<br/>

- Controller

```java
@PostMapping("/example")
public ResponseEntity<Dto> example(@AuthenticationPrincipal MemberDetails details) {

  Dto dto = service.doSomething(details.getId());

  return ResponseEntity.ok(dto);
}
```

이젠 따로 DB 조회 없이 회원의 id 정보를 세션에서 가져올 수 있습니다.

<br/>

## To Reviewers

게시글 동시성 테스트가 막힙니다. 확인 부탁드려요 ㅜ