### PR TITLE
[Feature/member] WithMockMember 어노테이션 구현

### DIFF
--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -2,7 +2,6 @@ package com.samcomo.dbz.report.controller;
 
 
 import com.samcomo.dbz.member.model.dto.MemberDetails;
-import com.samcomo.dbz.member.service.impl.MemberServiceImpl;
 import com.samcomo.dbz.report.model.dto.CustomSlice;
 import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportStateDto;

--- a/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
@@ -6,12 +6,12 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.jwt.filter.RefreshTokenFilter;
 import com.samcomo.dbz.member.model.dto.MemberMyInfo;
 import com.samcomo.dbz.member.model.dto.RegisterRequestDto;
 import com.samcomo.dbz.member.model.entity.Member;
@@ -34,6 +34,8 @@ class MemberControllerTest {
 
   @MockBean
   private MemberService memberService;
+  @MockBean
+  private RefreshTokenFilter refreshTokenFilter;
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -88,8 +90,7 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     objectMapper.writeValueAsString(request)))
-        .andExpect(status().isCreated())
-        .andDo(print());
+        .andExpect(status().isCreated());
   }
 
   @Test
@@ -114,8 +115,7 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("올바르지 않은 이메일 형식입니다."))
         .andExpect(jsonPath("$.nickname").doesNotExist())
         .andExpect(jsonPath("$.phone").doesNotExist())
-        .andExpect(jsonPath("$.password").doesNotExist())
-        .andDo(print());
+        .andExpect(jsonPath("$.password").doesNotExist());
   }
 
   @Test
@@ -140,8 +140,7 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.nickname").value("특수문자를 제외한 2~10자 사이로 입력해주세요."))
         .andExpect(jsonPath("$.phone").doesNotExist())
-        .andExpect(jsonPath("$.password").doesNotExist())
-        .andDo(print());
+        .andExpect(jsonPath("$.password").doesNotExist());
   }
 
   @Test
@@ -166,8 +165,7 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.nickname").doesNotExist())
         .andExpect(jsonPath("$.phone").value("올바르지 않은 전화번호 형식입니다."))
-        .andExpect(jsonPath("$.password").doesNotExist())
-        .andDo(print());
+        .andExpect(jsonPath("$.password").doesNotExist());
   }
 
   @Test
@@ -192,8 +190,7 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.nickname").doesNotExist())
         .andExpect(jsonPath("$.phone").doesNotExist())
-        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."))
-        .andDo(print());
+        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."));
   }
 
   @Test
@@ -218,8 +215,7 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("올바르지 않은 이메일 형식입니다."))
         .andExpect(jsonPath("$.nickname").value("특수문자를 제외한 2~10자 사이로 입력해주세요."))
         .andExpect(jsonPath("$.phone").value("올바르지 않은 전화번호 형식입니다."))
-        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."))
-        .andDo(print());
+        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."));
   }
 
   @Test
@@ -240,8 +236,7 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("이메일" + REQUIRED_FIELD_MESSAGE))
         .andExpect(jsonPath("$.nickname").value("닉네임" + REQUIRED_FIELD_MESSAGE))
         .andExpect(jsonPath("$.phone").value("전화번호" + REQUIRED_FIELD_MESSAGE))
-        .andExpect(jsonPath("$.password").value("비밀번호" + REQUIRED_FIELD_MESSAGE))
-        .andDo(print());
+        .andExpect(jsonPath("$.password").value("비밀번호" + REQUIRED_FIELD_MESSAGE));
   }
 
   @Test
@@ -287,7 +282,6 @@ class MemberControllerTest {
             get("/member/my")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound())
-        .andDo(print());
+        .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/com/samcomo/dbz/utils/WithMemberSecurityContextFactory.java
+++ b/src/test/java/com/samcomo/dbz/utils/WithMemberSecurityContextFactory.java
@@ -1,0 +1,29 @@
+package com.samcomo.dbz.utils;
+
+import static com.samcomo.dbz.member.model.constants.MemberRole.MEMBER;
+
+import com.samcomo.dbz.member.model.dto.MemberDetails;
+import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.utils.annotation.WithMockMember;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMemberSecurityContextFactory implements WithSecurityContextFactory<WithMockMember> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockMember annotation) {
+
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+    MemberDetails details = new MemberDetails(Member.builder().id(1L).role(MEMBER).build());
+
+    Authentication auth = new UsernamePasswordAuthenticationToken(
+        details, null, details.getAuthorities());
+
+    context.setAuthentication(auth);
+    return context;
+  }
+}

--- a/src/test/java/com/samcomo/dbz/utils/annotation/WithMockMember.java
+++ b/src/test/java/com/samcomo/dbz/utils/annotation/WithMockMember.java
@@ -1,0 +1,16 @@
+package com.samcomo.dbz.utils.annotation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.samcomo.dbz.utils.WithMemberSecurityContextFactory;
+import java.lang.annotation.Retention;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RUNTIME)
+@WithSecurityContext(factory = WithMemberSecurityContextFactory.class)
+public @interface WithMockMember {
+
+  String value() default "member";
+
+  String[] roles() default { "MEMBER" };
+}


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
- [x] Test 완료 여부

### 기존 방식

테스트 시 인가처리를 위해 기존에는 아래 어노테이션을 사용했습니다.

```java
@Test
@WithMockUser(username = "test@gmail.com", roles = {"MEMBER"})
void test() ...
```

### 구현 이후 방식

컨트롤러 단에서 memberDetails 의 id 정보를 가져오기 위해서는 username, roles 가 아닌 id, role 키값을 가진 정보가 필요합니다.  
따라서 커스텀 어노테이션을 구현했습니다.

```java
@Test
@WithMockMember
void test() ...
```

기존 어노테이션보다 훨씬 간결하고, 테스트 코드에 집중할 수 있는 장점과 필요한 정보를 담은 MemberDetails 를 사용할 수 있다는 장점이 있습니다.

<br/>

## To Reviewers
<!-- 팀원에게 전달할 사항이나 질문 등을 자유롭게 적어주세요. -->

member 의 마이페이지 조회하는 테스트코드를 참고해서 테스트 작성 시 구현된 어노테이션을 사용해주세요.
report controller 에서 현재는 사라진 memberService 의 메서드 관련 부분은 삭제했습니다!