### PR TITLE
[Feature/logout] 필터를 이용한 로그아웃 구현

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -1,14 +1,19 @@
 package com.samcomo.dbz.global.config;
 
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+
 import com.samcomo.dbz.member.jwt.JwtUtil;
 import com.samcomo.dbz.member.jwt.filter.AccessTokenFilter;
+import com.samcomo.dbz.member.jwt.filter.CustomLoginFilter;
+import com.samcomo.dbz.member.jwt.filter.CustomLogoutFilter;
 import com.samcomo.dbz.member.jwt.filter.FilterMemberExceptionHandler;
-import com.samcomo.dbz.member.jwt.filter.LoginFilter;
-import com.samcomo.dbz.member.model.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -27,12 +32,10 @@ public class SecurityConfig {
 
   private final JwtUtil jwtUtil;
   private final AuthenticationConfiguration configuration;
-  private final RefreshTokenRepository refreshTokenRepository;
 
   @Bean
   public AuthenticationManager authenticationManager(
       AuthenticationConfiguration configuration) throws Exception {
-
     return configuration.getAuthenticationManager();
   }
 
@@ -53,29 +56,30 @@ public class SecurityConfig {
     http
         .authorizeHttpRequests((auth) -> auth
             .requestMatchers(
-                "/member/register",
-                "/member/login",
-                "/member/reissue",
+                "/member/register", // 회원가입
+                "/member/login", // 로그인
+                "/member/reissue", // accessToken 재발급
                 "/docs/**",
                 "/v3/api-docs/**",
                 "/aop/",
                 "/actuator/**"
             ).permitAll()
             // member
-            .requestMatchers("/report/**").hasRole("MEMBER")
+            .requestMatchers(GET, "/member/my").hasRole("MEMBER") // 마이페이지
+            .requestMatchers(PATCH, "/member/location").hasRole("MEMBER") // 위치 정보 업데이트
             // report
             .requestMatchers("/report/**").hasRole("MEMBER")
             // pin
-            .requestMatchers(HttpMethod.POST, "/pin").hasRole("MEMBER") // Pin 생성
-            .requestMatchers(HttpMethod.PUT, "/pin/{pinId}").hasRole("MEMBER") // Pin 수정
-            .requestMatchers(HttpMethod.DELETE, "/pin/{pinId}").hasRole("MEMBER") // Pin 삭제
-            .requestMatchers(HttpMethod.GET, "/pin/report/{reportId}/pin-list").hasRole("MEMBER") // Report 의 Pin List 가져오기
-            .requestMatchers(HttpMethod.GET, "/pin/{pinId}").hasRole("MEMBER") // Pin 상세정보 가져오기
+            .requestMatchers(POST, "/pin").hasRole("MEMBER") // Pin 생성
+            .requestMatchers(PUT, "/pin/{pinId}").hasRole("MEMBER") // Pin 수정
+            .requestMatchers(DELETE, "/pin/{pinId}").hasRole("MEMBER") // Pin 삭제
+            .requestMatchers(GET, "/pin/report/{reportId}/pin-list").hasRole("MEMBER") // Report 의 Pin List 가져오기
+            .requestMatchers(GET, "/pin/{pinId}").hasRole("MEMBER") // Pin 상세정보 가져오기
             // chat
-            .requestMatchers(HttpMethod.POST, "/chat/room").hasRole("MEMBER") // 채팅방 생성
-            .requestMatchers(HttpMethod.GET, "/chat/member/room-list").hasRole("MEMBER") // 회원 채팅방 목록 조회
-            .requestMatchers(HttpMethod.GET, "/chat/room/{chatRoomId}/message-list").hasRole("MEMBER") // 채팅방 메시지 목록 조회
-            .requestMatchers(HttpMethod.DELETE, "/chat/room/{chatRoomId}").hasRole("MEMBER") // 채팅방 삭제
+            .requestMatchers(POST, "/chat/room").hasRole("MEMBER") // 채팅방 생성
+            .requestMatchers(GET, "/chat/member/room-list").hasRole("MEMBER") // 회원 채팅방 목록 조회
+            .requestMatchers(GET, "/chat/room/{chatRoomId}/message-list").hasRole("MEMBER") // 채팅방 메시지 목록 조회
+            .requestMatchers(DELETE, "/chat/room/{chatRoomId}").hasRole("MEMBER") // 채팅방 삭제
             .anyRequest().authenticated());
 
     // session : stateless
@@ -85,11 +89,14 @@ public class SecurityConfig {
 
     // filter
     http
-        .addFilterBefore(new FilterMemberExceptionHandler(), LogoutFilter.class) // TODO : 커스텀 로그아웃 필터로 변경
         .addFilterBefore(
-            new LoginFilter(authenticationManager(configuration), jwtUtil, refreshTokenRepository),
-            UsernamePasswordAuthenticationFilter.class)
-        .addFilterBefore(new AccessTokenFilter(jwtUtil), LoginFilter.class);
+            new CustomLogoutFilter(jwtUtil), LogoutFilter.class)
+        .addFilterBefore(
+            new FilterMemberExceptionHandler(), CustomLogoutFilter.class)
+        .addFilterBefore(
+            new CustomLoginFilter(authenticationManager(configuration), jwtUtil), UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(
+            new AccessTokenFilter(jwtUtil), CustomLoginFilter.class);
 
     return http.build();
   }

--- a/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
+++ b/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
@@ -50,6 +50,12 @@ public enum ErrorCode {
 
   REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "사용할 수 없는 refresh 토큰입니다. 다시 로그인해주세요."),
 
+  ALREADY_LOGGED_OUT(HttpStatus.BAD_REQUEST, "이미 로그아웃 되어있는 사용자입니다."),
+
+  ALREADY_LOGGED_IN(HttpStatus.BAD_REQUEST, "이미 로그인 되어있는 사용자입니다."),
+
+  AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "로그인 인증에 실패했습니다."),
+
   // Pin
 
   PIN_NOT_FOUND(HttpStatus.BAD_REQUEST, "핀 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -1,18 +1,20 @@
 package com.samcomo.dbz.member.jwt;
 
-
-import static com.samcomo.dbz.global.exception.ErrorCode.TOKEN_NOT_FOUND;
-
-import com.samcomo.dbz.global.exception.ErrorCode;
-import com.samcomo.dbz.member.exception.MemberException;
-import com.samcomo.dbz.member.model.constants.TokenType;
-import static com.samcomo.dbz.global.exception.ErrorCode.TOKEN_NOT_FOUND;
 import static com.samcomo.dbz.global.exception.ErrorCode.ACCESS_TOKEN_EXPIRED;
+import static com.samcomo.dbz.global.exception.ErrorCode.ALREADY_LOGGED_IN;
 import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_ACCESS_TOKEN;
 import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_REFRESH_TOKEN;
 import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_TOKEN_TYPE;
 import static com.samcomo.dbz.global.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
 import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
+import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
+
+import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.model.constants.MemberRole;
+import com.samcomo.dbz.member.model.constants.TokenType;
+import com.samcomo.dbz.member.model.dto.MemberDetails;
+import com.samcomo.dbz.member.model.entity.RefreshToken;
+import com.samcomo.dbz.member.model.repository.RefreshTokenRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -30,10 +32,12 @@ public class JwtUtil {
   private static final String ROLE_KEY = "role";
 
   private final SecretKey secretKey;
+  private final RefreshTokenRepository refreshTokenRepository;
 
-  private JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+  private JwtUtil(@Value("${spring.jwt.secret}") String secret, RefreshTokenRepository refreshTokenRepository) {
     this.secretKey = new SecretKeySpec(
         secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    this.refreshTokenRepository = refreshTokenRepository;
   }
 
   public Long getId(String token) {
@@ -59,9 +63,18 @@ public class JwtUtil {
     return getTokenType(token).equals(tokenType.getKey());
   }
 
+  public MemberDetails extractMemberDetailsFrom(String accessToken) {
+    validateTokenAndTokenType(accessToken, ACCESS_TOKEN);
+
+    Long memberId = getId(accessToken);
+    MemberRole role = MemberRole.get(getRole(accessToken))
+        .orElseThrow(() -> new MemberException(INVALID_ACCESS_TOKEN));
+
+    return MemberDetails.of(memberId, role);
+  }
+
   public void validateTokenAndTokenType(String token, TokenType requiredTokenType) {
     boolean isRequiredAccessType = isAccessTokenType(requiredTokenType);
-
     try {
       if (!isTokenTypeCorrect(token, requiredTokenType)) {
         throw new MemberException(INVALID_TOKEN_TYPE);
@@ -74,6 +87,34 @@ public class JwtUtil {
     }
   }
 
+  public boolean isRefreshTokenInDataBase(String refreshToken) {
+    Long memberId = getId(refreshToken);
+    return refreshTokenRepository.existsByRefreshTokenAndMemberId(refreshToken, memberId);
+  }
+
+  public void saveRefreshTokenToDataBase(Long memberId, String refreshToken) {
+    Date expiration = new Date(System.currentTimeMillis() + REFRESH_TOKEN.getExpiredMs());
+    refreshTokenRepository.save(RefreshToken.builder()
+        .memberId(memberId)
+        .refreshToken(refreshToken)
+        .expiration(String.valueOf(expiration))
+        .build());
+  }
+
+  public void deleteRefreshTokenFromDataBase(String refreshToken) {
+    refreshTokenRepository.deleteByRefreshToken(refreshToken);
+  }
+
+  public void checkAlreadyLoggedIn(Long memberId) {
+    if (refreshTokenRepository.existsByMemberId(memberId)) {
+      throw new MemberException(ALREADY_LOGGED_IN);
+    }
+  }
+
+  public void deleteAllRefreshTokenFromDataBase(String oldRefreshToken) {
+    refreshTokenRepository.deleteAllByMemberId(getId(oldRefreshToken));
+  }
+
   public String createToken(TokenType tokenType, String id, String role) {
     return Jwts.builder()
         .subject(tokenType.getKey())
@@ -83,15 +124,5 @@ public class JwtUtil {
         .expiration(new Date(System.currentTimeMillis() + tokenType.getExpiredMs()))
         .signWith(secretKey)
         .compact();
-  }
-  public void validateAccessToken(String token){
-    if(token != null && !token.isEmpty()){
-      throw new MemberException(TOKEN_NOT_FOUND);
-    }
-    try{
-      Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
-    } catch (JwtException | IllegalArgumentException e){
-      throw new MemberException(ErrorCode.INVALID_ACCESS_TOKEN);
-    }
   }
 }

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/CustomLogoutFilter.java
@@ -1,0 +1,87 @@
+package com.samcomo.dbz.member.jwt.filter;
+
+import static com.samcomo.dbz.global.exception.ErrorCode.ALREADY_LOGGED_OUT;
+import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
+
+import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+  private final JwtUtil jwtUtil;
+
+  private static final String LOGOUT_URI = "\\/member\\/logout";
+  private static final String LOGOUT_METHOD = "POST";
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+  }
+
+  private void doFilter(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws IOException, ServletException {
+
+    if (!isLogoutRequest(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String refreshToken = getRefreshToken(request);
+    validateRefreshToken(refreshToken);
+
+    jwtUtil.deleteRefreshTokenFromDataBase(refreshToken);
+    deleteCookie(response);
+    response.setStatus(HttpServletResponse.SC_OK);
+  }
+
+  private void validateRefreshToken(String refreshToken) {
+    jwtUtil.validateTokenAndTokenType(refreshToken, REFRESH_TOKEN);
+    if (!isTokenInDataBase(refreshToken)) {
+      throw new MemberException(ALREADY_LOGGED_OUT);
+    }
+  }
+  private void deleteCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie(REFRESH_TOKEN.getKey(), null);
+    cookie.setMaxAge(0);
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    // cookie.setSecure(true);
+    response.addCookie(cookie);
+  }
+
+  private String getRefreshToken(HttpServletRequest request) {
+    String refreshToken = null;
+
+    Cookie[] cookies = request.getCookies();
+    for (Cookie cookie : cookies) {
+      if (cookie.getName().equals(REFRESH_TOKEN.getKey())) {
+        refreshToken = cookie.getValue();
+      }
+    }
+    return refreshToken;
+  }
+
+  private boolean isLogoutRequest(HttpServletRequest request) {
+    if (!request.getMethod().equals(LOGOUT_METHOD)) {
+      return false;
+    }
+    return request.getRequestURI().matches(LOGOUT_URI);
+  }
+
+  private boolean isTokenInDataBase(String refreshToken) {
+    return jwtUtil.isRefreshTokenInDataBase(refreshToken);
+  }
+}

--- a/src/main/java/com/samcomo/dbz/member/model/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/samcomo/dbz/member/model/repository/RefreshTokenRepository.java
@@ -9,7 +9,10 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
   boolean existsByRefreshTokenAndMemberId(String refreshToken, Long memberId);
 
   @Transactional
-  void deleteByRefreshTokenAndMemberId(String refreshToken, Long memberId);
-
   void deleteAllByMemberId(Long memberId);
+
+  @Transactional
+  void deleteByRefreshToken(String refreshToken);
+
+  boolean existsByMemberId(Long memberId);
 }


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
- [x] Postman Test 완료 여부

### Logout Filter 동작 방식

spring security 에서 기본적으로 제공하는 LogoutFilter 도 있지만, 우리 프로젝트 상황에 맞게 커스텀하기 위해 해당 필터가 상속 받는 클래스 GenericFilterBean 를 직접 상속받아 구현했습니다.

CustomLogoutFilter 의 동작 방식은 아래와 같습니다.

```
1. 로그아웃을 위해 클라이언트가 "/member/logout" 으로 요청합니다.

2. 필터를 쭉 돌다가 제가 등록한 CustomLogoutFilter 에 도착합니다.

3. 해당 요청이 post 요청인지, uri 는 "/member/logout" 가 맞는지 검증합니다.

4-1. 만약 일치하지 않으면 로그아웃 요청이 아님을 인지하고 다음 필터로 넘어갑니다.
4-2. 만약 일치하면 로그아웃을 계속 진행합니다.

5. 해당 사용자의 쿠키에 담긴 refreshToken 을 가져옵니다.

6. refreshToken 이 유효한 값인지 검증합니다.

7-1. 유효하지 않다면 BadRequest(유효한 값이 아닙니다 or 이미 로그아웃된 사용자입니다.)  로 응답합니다.
7-2. 만약 유효하다면 쿠키의 refreshToken 을 null 값으로 할당하고, DB 에서 해당 토큰을 삭제합니다.

8. status 를 OK (200) 으로 응답합니다.
```

### 서버에서도 로그아웃을 하는 이유

로그인 성공 시 헤더에 Access-Token, 쿠키에 Refresh-Token 을 담아 반환했습니다.  
쿠키는 세션에 비해 보안성이 낮기 때문에 js 로 부터 오는 공격인 xss 접근에 취약합니다.
따라서 아래처럼 http only 설정을 통해 js 의 접근을 막았습니다.
```java
cookie.setHttpOnly(true);
```
하지만 이렇게 설정하면 프론트에서 접근하지 못합니다. 따라서 서버에서 쿠키의 Refresh-Token 값을 지워주어야 합니다.

<br/>

## 📚 References
<!-- 참고한 자료가 있다면 적어주세요 -->

![image](https://github.com/SamCoMo/DBZ-Backend/assets/126454114/fa69c851-7ef8-4bf6-848e-87822434e6f3)

기존 LogoutFilter 앞에 CustomLogoutFilter 를 등록했습니다.
기존 로그아웃 필터의 uri 는 get/post ("/logout") 이어야 `requiresLogout()` 를 통과하여 동작하게 됩니다.
하지만 저희 서비스의 로그아웃 uri 는 "/member/logout" 이기 때문에 기존 logout 필터는 동작하지 않습니다.

```java
// 기존 LogOutFilter 클래스
private void doFilter(...) throws IOException, ServletException {
  // requiresLogout() == false
  if (requiresLogout(request, response)) {
    // 로그아웃 동작 안 함.
  }

  // 다음 필터로 넘어감
  chain.doFilter(request, response);
}
```

<br/>

## To Reviewers
<!-- 팀원에게 전달할 사항이나 질문 등을 자유롭게 적어주세요. -->

Postman 과 DB 값이 잘 반영되는 걸 확인했지만 테스트 코드를 작성하진 못했습니다.
필터를 테스트하는 방법에 대해 공부하고 추후 작성하겠습니다!