### PR TITLE
[FEATURE/CHAT] WebSocket 연결시 JWT 검증 로직 추가

### DIFF
--- a/src/main/java/com/samcomo/dbz/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/samcomo/dbz/chat/config/WebSocketConfig.java
@@ -1,16 +1,34 @@
 package com.samcomo.dbz.chat.config;
 
+import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_ACCESS_TOKEN;
+import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_SESSION;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.jwt.JwtUtil;
+import com.samcomo.dbz.member.model.constants.MemberRole;
+import com.samcomo.dbz.member.model.dto.MemberDetails;
+import com.samcomo.dbz.member.model.entity.Member;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.DefaultContentTypeResolver;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -18,8 +36,12 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 // WebSocket 기반 MessageBroker 활성화
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+  private final JwtUtil jwtUtil;
+
+  // 메시지 브로커 구성 ( 메시지 보낼때 사용하는 경로 설정 )
   @Override
   public void configureMessageBroker (MessageBrokerRegistry registry){
     // "/chatapp 경로로 통해 들어오는 메시지 -> 애플레케이션 내부로 라우팅되어서 처리
@@ -28,7 +50,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         .enableSimpleBroker("/chatrooms"); // 채팅방별 메시지 브로커 활성화
   }
 
-
+  // STOMP 프로토콜 사용시 WebSocket 엔드포인트 : "/ws"
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry){
     registry.addEndpoint("/ws")
@@ -36,6 +58,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         .withSockJS();
   }
 
+  // 메시지 변환기 구성 및 메시지 형식 설정
   @Override
   public boolean configureMessageConverters(
       List<MessageConverter> messageConverters) {
@@ -49,5 +72,44 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     messageConverters.add(new ByteArrayMessageConverter());
     messageConverters.add(converter);
     return true;
+  }
+
+  // client -> 들어오는 메시지 처리 인터셉터 구성
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration){
+    registration.interceptors(new ChannelInterceptor() {
+      // 메시지가 전송되기 전에 호출 -> 사용자 인증처리
+      @Override
+      public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        // 클라이언트가 연결 시도
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+          String jwtToken = accessor.getFirstNativeHeader("Authorization");
+          if (jwtToken != null && !jwtToken.isEmpty() && jwtUtil.validateToken(jwtToken)) {
+            // 토큰이 유효한 경우 -> Authentication 정보 Security Context 에 저장
+            Long memberId = Long.valueOf(jwtUtil.getId(jwtToken));
+            MemberRole role = MemberRole.get(jwtUtil.getRole(jwtToken))
+                .orElseThrow(() -> new MemberException(INVALID_SESSION));
+
+            Member member = Member.builder()
+                .id(memberId)
+                .role(role)
+                .build();
+
+            MemberDetails memberDetails = new MemberDetails(member);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                memberDetails, null, memberDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+          } else {
+            throw new MemberException(INVALID_ACCESS_TOKEN);
+          }
+        }
+        return message;
+      }
+    });
   }
 }

--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.samcomo.dbz.member.model.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -57,7 +58,21 @@ public class SecurityConfig {
                 "/v3/api-docs/**",
                 "/aop/"
             ).permitAll()
-            .requestMatchers("/report/**", "/member/**").hasRole("MEMBER")
+            // member
+            .requestMatchers("/report/**").hasRole("MEMBER")
+            // report
+            .requestMatchers("/report/**").hasRole("MEMBER")
+            // pin
+            .requestMatchers(HttpMethod.POST, "/pin").hasRole("MEMBER") // Pin 생성
+            .requestMatchers(HttpMethod.PUT, "/pin/{pinId}").hasRole("MEMBER") // Pin 수정
+            .requestMatchers(HttpMethod.DELETE, "/pin/{pinId}").hasRole("MEMBER") // Pin 삭제
+            .requestMatchers(HttpMethod.GET, "/pin/report/{reportId}/pin-list").hasRole("MEMBER") // Report 의 Pin List 가져오기
+            .requestMatchers(HttpMethod.GET, "/pin/{pinId}").hasRole("MEMBER") // Pin 상세정보 가져오기
+            // chat
+            .requestMatchers(HttpMethod.POST, "/chat/room").hasRole("MEMBER") // 채팅방 생성
+            .requestMatchers(HttpMethod.GET, "/chat/member/room-list").hasRole("MEMBER") // 회원 채팅방 목록 조회
+            .requestMatchers(HttpMethod.GET, "/chat/room/{chatRoomId}/message-list").hasRole("MEMBER") // 채팅방 메시지 목록 조회
+            .requestMatchers(HttpMethod.DELETE, "/chat/room/{chatRoomId}").hasRole("MEMBER") // 채팅방 삭제
             .anyRequest().authenticated());
 
     // session : stateless

--- a/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
+++ b/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
 
   INVALID_SESSION(HttpStatus.UNAUTHORIZED, "세션 정보가 유효하지 않습니다."),
 
+  TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다."),
+
   ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "access 토큰이 만료되었습니다."),
 
   REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "refresh 토큰이 만료되었습니다."),

--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -1,5 +1,9 @@
 package com.samcomo.dbz.member.jwt;
 
+import static com.samcomo.dbz.global.exception.ErrorCode.TOKEN_NOT_FOUND;
+
+import com.samcomo.dbz.global.exception.ErrorCode;
+import com.samcomo.dbz.member.exception.MemberException;
 import com.samcomo.dbz.member.model.constants.TokenType;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -60,12 +64,14 @@ public class JwtUtil {
         .signWith(secretKey)
         .compact();
   }
-  public boolean validateToken(String token){
+  public void validateAccessToken(String token){
+    if(token != null && !token.isEmpty()){
+      throw new MemberException(TOKEN_NOT_FOUND);
+    }
     try{
       Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
-      return true;
     } catch (JwtException | IllegalArgumentException e){
-      return false;
+      throw new MemberException(ErrorCode.INVALID_ACCESS_TOKEN);
     }
   }
 }

--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.samcomo.dbz.member.jwt;
 
 import com.samcomo.dbz.member.model.constants.TokenType;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -58,5 +59,13 @@ public class JwtUtil {
         .expiration(new Date(System.currentTimeMillis() + tokenType.getExpiredMs()))
         .signWith(secretKey)
         .compact();
+  }
+  public boolean validateToken(String token){
+    try{
+      Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e){
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## ✨ Description

기존 STOMP 프로토콜을 이용하여 WebSocket 연결시 아무런 검증 로직이 없었습니다.  

로직을 추가하여 Client측에서 WebSocket 을 연결전에 jwt 토큰을 header에 추가해서 검증과정을 거쳐야 웹소켓 연결이 시작됩니다.

JWT토큰이 정상적으로 인증통과가 되면
SpringContext에 해당 JWT토큰에 관한 Authentication이 추가됩니다.

## 변경사항

- JWT String 토큰을 검증하는 로직 추가
- WebSocket 연결전 JwtToken 검증로직추가
- SpringSecurity : API주소별 HTTP 프로토콜 필터링 추가
- WebSocketConfig 의 메소드 주석추가
- validateAccessToken : JwtUtil의 메소드 수정

```
// ACCESS TOKEN 가져오기
String accessToken = accessor.getFirstNativeHeader(ACCESS_TOKEN.getKey());
```
로  변경되었기 때문에

프론트에서 JWT토큰값을 보낼때 Header값을 다음과 같이 코드를 변경해야합니다. 
```
const stompClient = new Client({
  webSocketFactory: () => new SockJS('/ws'),
  connectHeaders: {
    "Access-Token": qwehfwqejkhfkjwh12e11l1j2  // 임시 회원의 JWT토큰입니다. 
  },
  // 생략: onConnect, onStompError 등의 콜백 함수 구현
});
```

### 변경점 설명

- WebSocketConfig 및 JwtUtil에서는 "Access-Token"이라는 정확한 문자열 값을 사용하여 액세스 토큰을 추출하고 있습니다. 따라서 프론트엔드에서도 동일한 키를 사용해야 합니다.

- 일반적인 HTTP 요청에서 사용되는 "Authorization": "Bearer <token>" 형태와는 다르게 

- WebSocket 설정에서는 "Access-Token": "<token>" 형태로 토큰을 전송합니다. 따라서 "Authorization" 키 대신 "Access-Token" 키를 사용해야 하며, "Bearer " 접두사 없이 토큰 값만을 직접 전달해야 합니다.

### 프론트: 예시 메시지 보내기

// 채팅 메시지 예시
```
function sendMessage(chatRoomId, messageContent) {
    const message = {
        
        // 메시지의 내용을 추가 ( 명세 확인 )
        
    };
    stompClient.send(`/app/room/${chatRoomId}/message`, {}, JSON.stringify(message));
}
```
### 프론트: 예시 메시지 구독
// 채팅방 메시지 구독하기
```
function subscribeToChatRoom(chatRoomId) {
    stompClient.subscribe(`/chatrooms/${chatRoomId}`, (message) => {
        const messageData = JSON.parse(message.body);
        console.log("Received message:", messageData);
        // 예) 화면에 메시지를 표시하는 등의 작업필요
    });
}
```





