### PR TITLE
[FEATURE/MEMBER] Access Token 유효성 검사 API 추가 

### DIFF
--- a/src/main/java/com/samcomo/dbz/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/samcomo/dbz/chat/config/WebSocketConfig.java
@@ -8,6 +8,7 @@ import com.samcomo.dbz.member.jwt.JwtUtil;
 import com.samcomo.dbz.member.model.dto.MemberDetails;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -30,9 +31,9 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
-// WebSocket 기반 MessageBroker 활성화
-@EnableWebSocketMessageBroker
+@EnableWebSocketMessageBroker // WebSocket 기반 MessageBroker 활성화
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   private final JwtUtil jwtUtil;
@@ -79,23 +80,27 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
       public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(
             message, StompHeaderAccessor.class);
+        try{
+          if (isConnectionRequest(accessor)) {
+            String accessToken = getAccessToken(accessor);
+            MemberDetails memberDetails = jwtUtil.extractMemberDetailsFrom(accessToken);
 
-        if (isConnected(accessor)) {
-          String accessToken = getAccessTokenFrom(accessor);
-          MemberDetails memberDetails = jwtUtil.extractMemberDetailsFrom(accessToken);
+            // Authentication 생성 후 Security Context 에 저장
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                memberDetails, null, memberDetails.getAuthorities());
 
-          // Authentication 생성 후 Security Context 에 저장
-          Authentication authentication = new UsernamePasswordAuthenticationToken(
-              memberDetails, null, memberDetails.getAuthorities());
-
-          SecurityContextHolder.getContext().setAuthentication(authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+          }
+        } catch (Exception e){
+          log.error("WebSocket Auth Failed: {}", e.getMessage());
+          return null;
         }
         return message;
       }
     });
   }
 
-  private boolean isConnected(StompHeaderAccessor accessor) {
+  private boolean isConnectionRequest(StompHeaderAccessor accessor) {
     if (accessor == null) {
       return false;
     }
@@ -103,7 +108,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     return StompCommand.CONNECT.equals(accessor.getCommand());
   }
 
-  private String getAccessTokenFrom(StompHeaderAccessor accessor) {
+  private String getAccessToken(StompHeaderAccessor accessor) {
     return accessor.getFirstNativeHeader(ACCESS_TOKEN.getKey());
   }
 }

--- a/src/main/java/com/samcomo/dbz/member/controller/MemberController.java
+++ b/src/main/java/com/samcomo/dbz/member/controller/MemberController.java
@@ -1,13 +1,17 @@
 package com.samcomo.dbz.member.controller;
 
+import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
+import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN_KEY;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.samcomo.dbz.member.jwt.JwtUtil;
 import com.samcomo.dbz.member.jwt.filter.RefreshTokenFilter;
 import com.samcomo.dbz.member.model.dto.LocationUpdateRequest;
 import com.samcomo.dbz.member.model.dto.MemberDetails;
 import com.samcomo.dbz.member.model.dto.MyPageResponse;
 import com.samcomo.dbz.member.model.dto.RegisterRequest;
+import com.samcomo.dbz.member.model.dto.TokenValidationResponse;
 import com.samcomo.dbz.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,6 +37,7 @@ public class MemberController {
 
   private final MemberService memberService;
   private final RefreshTokenFilter refreshTokenFilter;
+  private final JwtUtil jwtUtil;
 
   @PostMapping("/register")
   @Operation(summary = "신규 회원 가입")
@@ -61,6 +67,16 @@ public class MemberController {
     refreshTokenFilter.reissue(refreshToken, response);
 
     return ResponseEntity.status(CREATED).build();
+  }
+
+  @GetMapping("/validate-token")
+  @Operation(summary = " access 토큰 유효성 검사")
+  public ResponseEntity<TokenValidationResponse> validateAccessToken(
+      @RequestHeader(ACCESS_TOKEN_KEY) String accessToken
+  ){
+    TokenValidationResponse tokenValidationResponse
+        = jwtUtil.getTokenValidationResponse(accessToken, ACCESS_TOKEN);
+    return ResponseEntity.ok(tokenValidationResponse);
   }
 
   @PatchMapping("/location")

--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -13,6 +13,7 @@ import com.samcomo.dbz.member.exception.MemberException;
 import com.samcomo.dbz.member.model.constants.MemberRole;
 import com.samcomo.dbz.member.model.constants.TokenType;
 import com.samcomo.dbz.member.model.dto.MemberDetails;
+import com.samcomo.dbz.member.model.dto.TokenValidationResponse;
 import com.samcomo.dbz.member.model.entity.RefreshToken;
 import com.samcomo.dbz.member.model.repository.RefreshTokenRepository;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -84,6 +85,27 @@ public class JwtUtil {
           isRequiredAccessType ? ACCESS_TOKEN_EXPIRED : REFRESH_TOKEN_EXPIRED);
     } catch (JwtException | IllegalArgumentException e) {
       throw new MemberException(isRequiredAccessType ? INVALID_ACCESS_TOKEN : INVALID_REFRESH_TOKEN);
+    }
+  }
+
+  public TokenValidationResponse getTokenValidationResponse(String token,TokenType requiredTokenType){
+    final String VALID_TOKEN_MESSAGE = "Token is Valid";
+    try {
+      validateTokenAndTokenType(token, requiredTokenType);
+      // 토큰이 유효한 경우
+      return TokenValidationResponse.builder()
+          .isValid(true)
+          .isExpired(false)
+          .build();
+    }catch (MemberException e){
+      // 만료 여부 판단
+      boolean isExpired = e.getErrorCode() == ACCESS_TOKEN_EXPIRED ||
+          e.getErrorCode() == REFRESH_TOKEN_EXPIRED;
+      // 토큰이 만료 or 유효하지않은 경우
+      return TokenValidationResponse.builder()
+          .isValid(false)
+          .isExpired(isExpired)
+          .build();
     }
   }
 

--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -89,7 +89,6 @@ public class JwtUtil {
   }
 
   public TokenValidationResponse getTokenValidationResponse(String token,TokenType requiredTokenType){
-    final String VALID_TOKEN_MESSAGE = "Token is Valid";
     try {
       validateTokenAndTokenType(token, requiredTokenType);
       // 토큰이 유효한 경우

--- a/src/main/java/com/samcomo/dbz/member/model/constants/TokenType.java
+++ b/src/main/java/com/samcomo/dbz/member/model/constants/TokenType.java
@@ -10,6 +10,9 @@ public enum TokenType {
   ACCESS_TOKEN("Access-Token", 6000L * 10 * 1000),  // 10분
   REFRESH_TOKEN("Refresh-Token", 6000L * 10 * 60 * 24);  // 24시간
 
+  public static final String ACCESS_TOKEN_KEY = "Access-Token";
+  public static final String REFRESH_TOKEN_KEY = "Refresh-Token";
+
   private final String key;
   private final Long expiredMs;
 }

--- a/src/main/java/com/samcomo/dbz/member/model/dto/TokenValidationResponse.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/TokenValidationResponse.java
@@ -1,0 +1,11 @@
+package com.samcomo.dbz.member.model.dto;
+
+import lombok.Builder;
+import lombok.Setter;
+
+@Setter
+@Builder
+public class TokenValidationResponse {
+  private Boolean isValid;
+  private Boolean isExpired;
+}


### PR DESCRIPTION
## 📌 Issues #80
API 명세: Access Token 유효성 검사

- 요청 URL
GET /validate-token

- 요청 헤더
    - Access-Token: {accessToken} 
    
- Response

```
{
  "isValid": true,
  "isExpired": false
}
```

- isValid: Boolean 
    - 토큰의 유효성 -> 유효할 경우 true, 않을 경우 false를 반환
- isExpired: Boolean
    - 토큰의 만료 여부 -> 만료되었을 경우 true, 유효할 경우 false를 반환합니다.

- 처리 로직
요청 헤더에서 Access-Token을 추출합니다.
추출한 토큰을 사용하여 유효성을 검사한뒤 결과를 반환합니다.

- 토큰이 유효한 경우
```
{
  "isValid": true,
  "isExpired": false
}
```
    
- 토큰이 만료된 경우
```
{
  "isValid": false,
  "isExpired": true
}
```
    
- 토큰이 유효하지 않은 경우 (변조된 토큰, 잘못된 서명)
```
{
  "isValid": false,
  "isExpired": false
}
```
    
## 고려사항
- 에러 메시지 최소화: 클라이언트에게 구체적인 에러 메시지를 제공하지 않고, 토큰의 유효성과 만료 여부만을 간결하게 반환합니다. 공격자가 에러 메시지를 통해 시스템의 내부 정보를 유추하는 것을 방지합니다.


## WebSocket 요청
- 클라이언트는 이 API를 통해 자신이 소유한 토큰의 상태를 빠르게 확인하고, 필요한 경우 토큰 재발급 요청을 처리합니다.

이후 WebSocket 엔드포인트에 웹소켓 연결요청을 진행합니다.


<br/>
