### PR TITLE
[Fix/Local-Error] 커밋 중복 현상 해결

### DIFF
--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -41,8 +41,9 @@ public class JwtUtil {
   }
 
   public Long getId(String token) {
-    return Long.valueOf(Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-        .get(ID_KEY, String.class));
+    return Long.valueOf(
+        Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+            .get(ID_KEY, String.class));
   }
 
   public String getRole(String token) {
@@ -83,7 +84,8 @@ public class JwtUtil {
       throw new MemberException(
           isRequiredAccessType ? ACCESS_TOKEN_EXPIRED : REFRESH_TOKEN_EXPIRED);
     } catch (JwtException | IllegalArgumentException e) {
-      throw new MemberException(isRequiredAccessType ? INVALID_ACCESS_TOKEN : INVALID_REFRESH_TOKEN);
+      throw new MemberException(
+          isRequiredAccessType ? INVALID_ACCESS_TOKEN : INVALID_REFRESH_TOKEN);
     }
   }
 


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

### 문제상황

![스크린샷 2024-03-24 오후 4 32 02](https://github.com/SamCoMo/DBZ-Backend/assets/126454114/c906c719-680d-4331-bc3e-855d30014462)


pr 을 올릴 때마다 기존 커밋이 중복되어 올라오는 문제가 발생했습니다.
아무런 작업을 하지 않고 push 를 하여도 이전 커밋이 같이 올라옵니다.

<br/>

### 원인

너무 안 좋은 기억은 까먹나봐요...정확히 기억이 나지는 않습니만,

이틀 전 3개 정도의 pr 을 올렸고, 각각의 pr 은 서로 다른 기능 개발이었습니다.
하지만 각각의 pr 을 순차적으로 merge 하는 과정에서 최신상태로 유지되어야 하는 코드가 다른 pr 이 merge 됨에 따라 사라진 듯 합니다.

문제가 되는 develop 브랜치의 내용이 아닌, 현재 로컬에 있는 최신상태의 브랜치를 기준으로 덮어 씌우기 위해 rebase 를 사용하였습니다.

문제는 rebase 대상 브랜치가 develop 이 었고, 이 develop 브랜치에 변경점이 생기면서 git log가 꼬인 것 같습니다.

<br/>

### 해결

해결방법을 모색하다 rebase 로 커밋의 위치를 변경시키거나 삭제해서 가능하다는 사실을 알았습니다.
배포 직전 단계에서 위험성을 부담하고 rebase 로 해결하기 보다는,
중복 커밋이 발생하는 브랜치를 삭제 후 다시 원격 저장소에서 새로 브랜치를 받아와 작업하는 것이 수월하다고 판단했습니다.

따라서 main, develop, feature 브랜치를 모두 삭제하고 다시 원격 저장소의 브랜치를 가져와 작업합니다.

<br/>

### 추가

rebase 의 단점은 공용으로 사용하는 브랜치가 잘못하면 다 날라가거나 원치 않는 방향으로 바뀔 수 있기 때문에 조심해서 사용해야 합니다.

이런 위험성을 안고도 rebase 를 사용하는 분들이 많은 이유는 여러개로 분기되는 브랜치의 수많은 커밋을 깔끔하게 관리할 수 있기 때문입니다.

다음 번에 다시 사용할 기회가 생기면 제대로 위험성을 숙지하고 사용해야겠습니다!

