### PR TITLE
Feature/update profile image

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
+++ b/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
@@ -56,6 +56,8 @@ public enum ErrorCode {
 
   AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "로그인 인증에 실패했습니다."),
 
+  PROFILE_IMAGE_NOT_UPLOADED(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 이미지 업데이트에 실패했습니다."),
+
   // Pin
 
   PIN_NOT_FOUND(HttpStatus.BAD_REQUEST, "핀 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/samcomo/dbz/global/s3/constants/ImageCategory.java
+++ b/src/main/java/com/samcomo/dbz/global/s3/constants/ImageCategory.java
@@ -9,7 +9,8 @@ public enum ImageCategory {
 
   REPORT("report"),
   PIN("pin"),
-  CHAT("chat");
+  CHAT("chat"),
+  MEMBER("member");
 
   private final String name;
 }

--- a/src/main/java/com/samcomo/dbz/global/s3/service/S3Service.java
+++ b/src/main/java/com/samcomo/dbz/global/s3/service/S3Service.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -105,10 +106,13 @@ public class S3Service {
 
   private void deleteUploadedImageList(List<String> imageUrlList) {
     for (String imageUrl : imageUrlList) {
-      int idx = imageUrl.lastIndexOf("/");
-      String fileName = imageUrl.substring(idx + 1);
-      deleteFile(fileName);
+      deleteFile(getFileName(imageUrl));
     }
+  }
+
+  @NotNull
+  public String getFileName(String imageUrl) {
+    return imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
   }
 
   // Base64 이미지 업로드

--- a/src/main/java/com/samcomo/dbz/member/controller/MemberController.java
+++ b/src/main/java/com/samcomo/dbz/member/controller/MemberController.java
@@ -3,9 +3,8 @@ package com.samcomo.dbz.member.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-import com.samcomo.dbz.member.jwt.JwtUtil;
 import com.samcomo.dbz.member.jwt.filter.RefreshTokenFilter;
-import com.samcomo.dbz.member.model.dto.LocationUpdateRequest;
+import com.samcomo.dbz.member.model.dto.LocationRequest;
 import com.samcomo.dbz.member.model.dto.MemberDetails;
 import com.samcomo.dbz.member.model.dto.MyPageResponse;
 import com.samcomo.dbz.member.model.dto.RegisterRequest;
@@ -23,7 +22,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,7 +34,6 @@ public class MemberController {
 
   private final MemberService memberService;
   private final RefreshTokenFilter refreshTokenFilter;
-  private final JwtUtil jwtUtil;
 
   @PostMapping("/register")
   @Operation(summary = "신규 회원 가입")
@@ -69,9 +69,20 @@ public class MemberController {
   @Operation(summary = "회원 위치 업데이트")
   public ResponseEntity<Void> updateLocation(
       @AuthenticationPrincipal MemberDetails details,
-      @Valid @RequestBody LocationUpdateRequest request) {
+      @Valid @RequestBody LocationRequest request) {
 
     memberService.updateLocation(details.getId(), request);
+
+    return ResponseEntity.status(OK).build();
+  }
+
+  @PatchMapping("/profile-image")
+  @Operation(summary = "프로필 이미지 업데이트")
+  public ResponseEntity<Void> updateProfileImage(
+      @AuthenticationPrincipal MemberDetails details,
+      @RequestPart MultipartFile profileImage) {
+
+    memberService.updateProfileImage(details.getId(), profileImage);
 
     return ResponseEntity.status(OK).build();
   }

--- a/src/main/java/com/samcomo/dbz/member/model/dto/LocationRequest.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/LocationRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class LocationUpdateRequest {
+public class LocationRequest {
 
   private static final String REQUIRED_FIELD_MESSAGE = "는 필수 항목입니다.";
 

--- a/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
+++ b/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
@@ -67,7 +67,6 @@ public class Member extends BaseEntity {
     return Member.builder()
         .email(request.getEmail())
         .nickname(request.getNickname())
-        .profileImageUrl("defaultImageUrl.jpg") // TODO 기본 이미지 url 정하기
         .phone(request.getPhone())
         .role(MEMBER)
         .status(ACTIVE)

--- a/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
+++ b/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
@@ -38,6 +38,7 @@ public class Member extends BaseEntity {
 
   private String nickname;
 
+  @Setter
   private String profileImageUrl;
 
   private String phone;

--- a/src/main/java/com/samcomo/dbz/member/service/MemberService.java
+++ b/src/main/java/com/samcomo/dbz/member/service/MemberService.java
@@ -1,10 +1,11 @@
 package com.samcomo.dbz.member.service;
 
-import com.samcomo.dbz.member.model.dto.LocationUpdateRequest;
+import com.samcomo.dbz.member.model.dto.LocationRequest;
 import com.samcomo.dbz.member.model.dto.MyPageResponse;
 import com.samcomo.dbz.member.model.dto.RegisterRequest;
 import com.samcomo.dbz.member.model.entity.Member;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public interface MemberService {
@@ -15,7 +16,9 @@ public interface MemberService {
 
   MyPageResponse getMyInfo(long memberId);
 
-  void updateLocation(long memberId, LocationUpdateRequest request);
+  void updateLocation(long memberId, LocationRequest request);
 
   Member getMember(long memberId);
+
+  void updateProfileImage(long memberId, MultipartFile profileImage);
 }

--- a/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
@@ -62,7 +62,11 @@ public class MemberServiceImpl implements MemberService {
     if (!imageUploadState.isSuccess()) {
       throw new MemberException(PROFILE_IMAGE_NOT_UPLOADED);
     }
-    s3Service.deleteFile(s3Service.getFileName(member.getProfileImageUrl()));
+
+    String oldProfileImageUrl = member.getProfileImageUrl();
+    if (oldProfileImageUrl != null) {
+      s3Service.deleteFile(s3Service.getFileName(oldProfileImageUrl));
+    }
 
     member.setProfileImageUrl(imageUploadState.getImageUrl());
     memberRepository.save(member);

--- a/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
@@ -3,9 +3,13 @@ package com.samcomo.dbz.member.service.impl;
 import static com.samcomo.dbz.global.exception.ErrorCode.EMAIL_ALREADY_EXISTS;
 import static com.samcomo.dbz.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.samcomo.dbz.global.exception.ErrorCode.NICKNAME_ALREADY_EXISTS;
+import static com.samcomo.dbz.global.exception.ErrorCode.PROFILE_IMAGE_NOT_UPLOADED;
+import static com.samcomo.dbz.global.s3.constants.ImageCategory.MEMBER;
 
+import com.samcomo.dbz.global.s3.constants.ImageUploadState;
+import com.samcomo.dbz.global.s3.service.S3Service;
 import com.samcomo.dbz.member.exception.MemberException;
-import com.samcomo.dbz.member.model.dto.LocationUpdateRequest;
+import com.samcomo.dbz.member.model.dto.LocationRequest;
 import com.samcomo.dbz.member.model.dto.MyPageResponse;
 import com.samcomo.dbz.member.model.dto.RegisterRequest;
 import com.samcomo.dbz.member.model.entity.Member;
@@ -14,6 +18,7 @@ import com.samcomo.dbz.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +26,7 @@ public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
+  private final S3Service s3Service;
 
   @Override
   public void register(RegisterRequest request) {
@@ -38,11 +44,27 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  public void updateLocation(long memberId, LocationUpdateRequest request) {
+  public void updateLocation(long memberId, LocationRequest request) {
     Member member = getMember(memberId);
     member.setAddress(request.getAddress());
     member.setLatitude(request.getLatitude());
     member.setLongitude(request.getLongitude());
+    memberRepository.save(member);
+  }
+
+  @Override
+  public void updateProfileImage(long memberId, MultipartFile profileImage) {
+    Member member = getMember(memberId);
+
+    ImageUploadState imageUploadState =
+        s3Service.uploadMultipartFileByStream(profileImage, MEMBER);
+
+    if (!imageUploadState.isSuccess()) {
+      throw new MemberException(PROFILE_IMAGE_NOT_UPLOADED);
+    }
+    s3Service.deleteFile(s3Service.getFileName(imageUploadState.getImageUrl()));
+
+    member.setProfileImageUrl(imageUploadState.getImageUrl());
     memberRepository.save(member);
   }
 

--- a/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/member/service/impl/MemberServiceImpl.java
@@ -62,7 +62,7 @@ public class MemberServiceImpl implements MemberService {
     if (!imageUploadState.isSuccess()) {
       throw new MemberException(PROFILE_IMAGE_NOT_UPLOADED);
     }
-    s3Service.deleteFile(s3Service.getFileName(imageUploadState.getImageUrl()));
+    s3Service.deleteFile(s3Service.getFileName(member.getProfileImageUrl()));
 
     member.setProfileImageUrl(imageUploadState.getImageUrl());
     memberRepository.save(member);


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
- [x] Test 완료 여부

### 엔드포인트

```java
// /member/profile-image
@PatchMapping("/profile-image")
```

member 의 프로필이미지를 부분수정하는 patch 메서드로 받습니다.
(put : 전체 수정, post : 등록)


<br/>

### 이미지 받기

```java
@RequestPart MultipartFile profileImage
```

파일은 form-data 타입의 파일로 받습니다.

<br/>

### 수정 로직

```java
// 회원을 검증하여 가져옵니다.
Member member = getMember(memberId);

// 이미지를 저장한 후 저장결과를 받습니다.
ImageUploadState imageUploadState =
    s3Service.uploadMultipartFileByStream(profileImage, MEMBER);

// 만약 저장에 실패했다면 에러를 반환합니다.(500)
if (!imageUploadState.isSuccess()) {
  throw new MemberException(PROFILE_IMAGE_NOT_UPLOADED);
}

// 저장에 성공했다면 회원의 기존 프로필 이미지는 삭제합니다.
String oldProfileImageUrl = member.getProfileImageUrl();
if (oldProfileImageUrl != null) {
  s3Service.deleteFile(s3Service.getFileName(oldProfileImageUrl));
}

// 새로운 이미지를 세팅 후 저장합니다.
member.setProfileImageUrl(imageUploadState.getImageUrl());
memberRepository.save(member);
```