### PR TITLE
fix: 알림을 보낼 회원이 없는 경우

### DIFF
--- a/src/main/java/com/samcomo/dbz/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/notification/service/NotificationServiceImpl.java
@@ -100,6 +100,9 @@ public class NotificationServiceImpl implements NotificationService {
   public void sendReportNotification(ReportDto.Form reportForm) {
 
     List<Member> memberList = getActiveMemberNearBy(reportForm);
+
+    if(memberList.isEmpty()) return;
+
     List<String> fcmTokenList = getFcmTokenList(memberList);
 
     SendReportDto sendReportDto = SendReportDto.from(reportForm.getDescriptions());


### PR DESCRIPTION

## ✨ Description
Report를 보낼 때 발생하는 알림에서
보낼 회원이 없는 경우 발생하는 에러를 수정했습니다.
<br/>