### PR TITLE
[Feat/member] 회원가입 시 회원 위치정보 저장

### DIFF
--- a/src/main/java/com/samcomo/dbz/member/model/dto/RegisterRequest.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/RegisterRequest.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.samcomo.dbz.global.utils.annotation.EmailCheck;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,5 +36,12 @@ public class RegisterRequest {
   @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
             message = "영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요.")
   private String password;
+
+  @NotNull(message = "주소" + REQUIRED_FIELD_MESSAGE)
+  private Double latitude;
+  @NotNull(message = "위도" + REQUIRED_FIELD_MESSAGE)
+  private Double longitude;
+  @NotNull(message = "경도" + REQUIRED_FIELD_MESSAGE)
+  private String address;
 }
 

--- a/src/main/java/com/samcomo/dbz/member/model/dto/RegisterRequest.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/RegisterRequest.java
@@ -37,11 +37,11 @@ public class RegisterRequest {
             message = "영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요.")
   private String password;
 
-  @NotNull(message = "주소" + REQUIRED_FIELD_MESSAGE)
-  private Double latitude;
   @NotNull(message = "위도" + REQUIRED_FIELD_MESSAGE)
-  private Double longitude;
+  private Double latitude;
   @NotNull(message = "경도" + REQUIRED_FIELD_MESSAGE)
+  private Double longitude;
+  @NotBlank(message = "주소" + REQUIRED_FIELD_MESSAGE)
   private String address;
 }
 

--- a/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
+++ b/src/main/java/com/samcomo/dbz/member/model/entity/Member.java
@@ -70,6 +70,9 @@ public class Member extends BaseEntity {
         .phone(request.getPhone())
         .role(MEMBER)
         .status(ACTIVE)
+        .address(request.getAddress())
+        .latitude(request.getLatitude())
+        .longitude(request.getLongitude())
         .build();
   }
 }

--- a/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samcomo/dbz/member/controller/MemberControllerTest.java
@@ -62,6 +62,9 @@ class MemberControllerTest {
   private String validPhone;
   private String validPassword;
   private String validProfileImageUrl;
+  private String validAddress;
+  private Double validLatitude;
+  private Double validLongitude;
   private MyPageResponse myPageResponse;
   private Member member;
   private static final String REQUIRED_FIELD_MESSAGE = "은(는) 필수 항목입니다.";
@@ -74,6 +77,9 @@ class MemberControllerTest {
     validNickname = "삼코모";
     validPassword = "abcd1234!";
     validProfileImageUrl = "image.jpg";
+    validAddress = "제주시";
+    validLatitude = 34.12345;
+    validLongitude = 127.12345;
 
     member = Member.builder()
         .id(1L)
@@ -81,6 +87,9 @@ class MemberControllerTest {
         .nickname(validNickname)
         .profileImageUrl(validProfileImageUrl)
         .phone(validPhone)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     request = RegisterRequest.builder()
@@ -88,6 +97,9 @@ class MemberControllerTest {
         .nickname(validNickname)
         .phone(validPhone)
         .password(validPassword)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     myPageResponse = MyPageResponse.from(member);
@@ -117,6 +129,9 @@ class MemberControllerTest {
         .nickname(validNickname)
         .phone(validPhone)
         .password(validPassword)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     mockMvc.perform(
@@ -129,7 +144,10 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("올바르지 않은 이메일 형식입니다."))
         .andExpect(jsonPath("$.nickname").doesNotExist())
         .andExpect(jsonPath("$.phone").doesNotExist())
-        .andExpect(jsonPath("$.password").doesNotExist());
+        .andExpect(jsonPath("$.password").doesNotExist())
+        .andExpect(jsonPath("$.address").doesNotExist())
+        .andExpect(jsonPath("$.latitude").doesNotExist())
+        .andExpect(jsonPath("$.longitude").doesNotExist());
   }
 
   @Test
@@ -142,6 +160,9 @@ class MemberControllerTest {
         .nickname("x")
         .phone(validPhone)
         .password(validPassword)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     mockMvc.perform(
@@ -154,7 +175,10 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.nickname").value("특수문자를 제외한 2~10자 사이로 입력해주세요."))
         .andExpect(jsonPath("$.phone").doesNotExist())
-        .andExpect(jsonPath("$.password").doesNotExist());
+        .andExpect(jsonPath("$.password").doesNotExist())
+        .andExpect(jsonPath("$.address").doesNotExist())
+        .andExpect(jsonPath("$.latitude").doesNotExist())
+        .andExpect(jsonPath("$.longitude").doesNotExist());
   }
 
   @Test
@@ -167,6 +191,9 @@ class MemberControllerTest {
         .nickname(validNickname)
         .phone("x")
         .password(validPassword)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     mockMvc.perform(
@@ -179,7 +206,10 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.nickname").doesNotExist())
         .andExpect(jsonPath("$.phone").value("올바르지 않은 전화번호 형식입니다."))
-        .andExpect(jsonPath("$.password").doesNotExist());
+        .andExpect(jsonPath("$.password").doesNotExist())
+        .andExpect(jsonPath("$.address").doesNotExist())
+        .andExpect(jsonPath("$.latitude").doesNotExist())
+        .andExpect(jsonPath("$.longitude").doesNotExist());
   }
 
   @Test
@@ -192,6 +222,9 @@ class MemberControllerTest {
         .nickname(validNickname)
         .phone(validPhone)
         .password("x")
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     mockMvc.perform(
@@ -204,7 +237,10 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.nickname").doesNotExist())
         .andExpect(jsonPath("$.phone").doesNotExist())
-        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."));
+        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."))
+        .andExpect(jsonPath("$.address").doesNotExist())
+        .andExpect(jsonPath("$.latitude").doesNotExist())
+        .andExpect(jsonPath("$.longitude").doesNotExist());
   }
 
   @Test
@@ -217,6 +253,7 @@ class MemberControllerTest {
         .nickname("x")
         .phone("x")
         .password("x")
+        .address("")
         .build();
 
     mockMvc.perform(
@@ -229,7 +266,11 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("올바르지 않은 이메일 형식입니다."))
         .andExpect(jsonPath("$.nickname").value("특수문자를 제외한 2~10자 사이로 입력해주세요."))
         .andExpect(jsonPath("$.phone").value("올바르지 않은 전화번호 형식입니다."))
-        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."));
+        .andExpect(jsonPath("$.password").value("영문자+특수문자+숫자를 포함하여 8자 이상 입력해주세요."))
+        .andExpect(jsonPath("$.address").value("주소" + REQUIRED_FIELD_MESSAGE))
+        .andExpect(jsonPath("$.latitude").value("위도" + REQUIRED_FIELD_MESSAGE))
+        .andExpect(jsonPath("$.longitude").value("경도" + REQUIRED_FIELD_MESSAGE))
+        .andDo(print());
   }
 
   @Test
@@ -250,7 +291,10 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.email").value("이메일" + REQUIRED_FIELD_MESSAGE))
         .andExpect(jsonPath("$.nickname").value("닉네임" + REQUIRED_FIELD_MESSAGE))
         .andExpect(jsonPath("$.phone").value("전화번호" + REQUIRED_FIELD_MESSAGE))
-        .andExpect(jsonPath("$.password").value("비밀번호" + REQUIRED_FIELD_MESSAGE));
+        .andExpect(jsonPath("$.password").value("비밀번호" + REQUIRED_FIELD_MESSAGE))
+        .andExpect(jsonPath("$.address").value("주소" + REQUIRED_FIELD_MESSAGE))
+        .andExpect(jsonPath("$.latitude").value("위도" + REQUIRED_FIELD_MESSAGE))
+        .andExpect(jsonPath("$.longitude").value("경도" + REQUIRED_FIELD_MESSAGE));
   }
 
   @Test

--- a/src/test/java/com/samcomo/dbz/member/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/samcomo/dbz/member/service/impl/MemberServiceImplTest.java
@@ -60,6 +60,9 @@ class MemberServiceImplTest {
   private String rawNickname;
   private String rawPhone;
   private String rawPassword;
+  private String validAddress;
+  private Double validLatitude;
+  private Double validLongitude;
 
   @BeforeEach
   void init() {
@@ -70,12 +73,18 @@ class MemberServiceImplTest {
     rawPhone = "010-1234-5678";
     rawNickname = "삼코모";
     rawPassword = "abcd123!";
+    validAddress = "제주시";
+    validLatitude = 34.12345;
+    validLongitude = 127.12345;
 
     request = RegisterRequest.builder()
         .email(rawEmail)
         .nickname(rawNickname)
         .phone(rawPhone)
         .password(rawPassword)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
 
     savedMember = Member.builder()
@@ -86,6 +95,9 @@ class MemberServiceImplTest {
         .password(passwordEncoder.encode(rawPassword))
         .role(MEMBER)
         .status(ACTIVE)
+        .address(validAddress)
+        .latitude(validLatitude)
+        .longitude(validLongitude)
         .build();
   }
 
@@ -109,6 +121,9 @@ class MemberServiceImplTest {
     assertEquals(request.getEmail(), captor.getValue().getEmail());
     assertEquals(request.getNickname(), captor.getValue().getNickname());
     assertEquals(request.getPhone(), captor.getValue().getPhone());
+    assertEquals(request.getAddress(), captor.getValue().getAddress());
+    assertEquals(request.getLatitude(), captor.getValue().getLatitude());
+    assertEquals(request.getLongitude(), captor.getValue().getLongitude());
 
     assertTrue(passwordEncoder.matches(rawPassword, savedMember.getPassword()));
   }


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->
- [x] Test 완료 여부

### 회원가입 시 위치정보를 같이 받습니다.

마이페이지에서 회원의 위치정보를 업데이트 할 수 있는 기능이 있습니다.
그리고, 이 위치를 기반으로 거리순 알림이 발생합니다.

그러나, 마이페이지에서 직접 회원 위치정보를 업데이트 하지 않으면 알림을 받지 못합니다.
이러한 문제를 해결하고자 회원가입 시 위치정보를 같이 받도록 수정합니다.