### PR TITLE
[Feature/member] 소셜 로그인 실패 핸들러 추가

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
+++ b/src/main/java/com/samcomo/dbz/global/exception/ErrorCode.java
@@ -56,6 +56,8 @@ public enum ErrorCode {
 
   AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "로그인 인증에 실패했습니다."),
 
+  SOCIAL_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증에 실패했습니다."),
+
   INVALID_FCM_TOKEN(HttpStatus.BAD_REQUEST, "fcm 토큰은 필수 항목입니다."),
 
   PROFILE_IMAGE_NOT_UPLOADED(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 이미지 업데이트에 실패했습니다."),

--- a/src/main/java/com/samcomo/dbz/member/jwt/AuthUtils.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/AuthUtils.java
@@ -3,8 +3,10 @@ package com.samcomo.dbz.member.jwt;
 import static lombok.AccessLevel.PRIVATE;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 
+@Getter
 @Component
 @AllArgsConstructor(access = PRIVATE)
 public class AuthUtils {
@@ -14,13 +16,5 @@ public class AuthUtils {
 
   public static AuthUtils of(JwtUtil jwtUtil, CookieUtil cookieUtil) {
     return new AuthUtils(jwtUtil, cookieUtil);
-  }
-
-  public JwtUtil getJwtUtil() {
-    return jwtUtil;
-  }
-
-  public CookieUtil getCookieUtil() {
-    return cookieUtil;
   }
 }

--- a/src/main/java/com/samcomo/dbz/member/jwt/CookieUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/CookieUtil.java
@@ -12,14 +12,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class CookieUtil {
 
-  public final static String COOKIE_KEY = "Set-Cookie";
+  public final static String SAME_SITE_CONFIG = "None";
 
   public String createCookie(String refreshToken) {
     return String.valueOf(
         ResponseCookie.from(REFRESH_TOKEN.getKey(), refreshToken)
             .path("/")
             .maxAge(24 * 60 * 60)
-            .sameSite("None")
+            .sameSite(SAME_SITE_CONFIG)
             .httpOnly(true)
             .secure(true)
             .build());
@@ -30,6 +30,7 @@ public class CookieUtil {
         ResponseCookie.from(REFRESH_TOKEN.getKey(), null)
             .path("/")
             .maxAge(0)
+            .sameSite(SAME_SITE_CONFIG)
             .httpOnly(true)
             .secure(true)
             .build());

--- a/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/JwtUtil.java
@@ -5,6 +5,8 @@ import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_ACCESS_TOKEN;
 import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_REFRESH_TOKEN;
 import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_TOKEN_TYPE;
 import static com.samcomo.dbz.global.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.ID;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.ROLE;
 import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
 import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
 
@@ -27,9 +29,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtUtil {
 
-  private static final String ID_KEY = "id";
-  private static final String ROLE_KEY = "role";
-
   private final SecretKey secretKey;
   private final RefreshTokenRepository refreshTokenRepository;
 
@@ -42,12 +41,12 @@ public class JwtUtil {
   public Long getId(String token) {
     return Long.valueOf(
         Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-            .get(ID_KEY, String.class));
+            .get(ID.getKey(), String.class));
   }
 
   public String getRole(String token) {
     return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
-        .get(ROLE_KEY, String.class);
+        .get(ROLE.getKey(), String.class);
   }
 
   private String getTokenType(String token) {
@@ -119,8 +118,8 @@ public class JwtUtil {
   public String createToken(TokenType tokenType, String id, String role) {
     return Jwts.builder()
         .subject(tokenType.getKey())
-        .claim(ID_KEY, id)
-        .claim(ROLE_KEY, role)
+        .claim(ID.getKey(), id)
+        .claim(ROLE.getKey(), role)
         .issuedAt(new Date(System.currentTimeMillis()))
         .expiration(new Date(System.currentTimeMillis() + tokenType.getExpiredMs()))
         .signWith(secretKey)

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/AccessTokenFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/AccessTokenFilter.java
@@ -1,6 +1,7 @@
 package com.samcomo.dbz.member.jwt.filter;
 
 import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
+import static com.samcomo.dbz.member.model.constants.UriKey.REISSUE;
 
 import com.samcomo.dbz.member.jwt.JwtUtil;
 import com.samcomo.dbz.member.model.dto.MemberDetails;
@@ -19,8 +20,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class AccessTokenFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
-
-  private final static String REISSUE_URI = "/member/reissue";
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -42,7 +41,7 @@ public class AccessTokenFilter extends OncePerRequestFilter {
   }
 
   private boolean isReIssueURI(HttpServletRequest request) {
-    return REISSUE_URI.equals(request.getRequestURI());
+    return REISSUE.getUri().equals(request.getRequestURI());
   }
 
   private String getAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/CustomLoginFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/CustomLoginFilter.java
@@ -2,9 +2,13 @@ package com.samcomo.dbz.member.jwt.filter;
 
 import static com.samcomo.dbz.global.exception.ErrorCode.AUTHENTICATION_FAILED;
 import static com.samcomo.dbz.global.exception.ErrorCode.INVALID_FCM_TOKEN;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.FCM_TOKEN;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.PASSWORD;
+import static com.samcomo.dbz.member.model.constants.UriKey.LOGIN;
 import static org.springframework.http.HttpMethod.POST;
 
 import com.samcomo.dbz.member.exception.MemberException;
+import com.samcomo.dbz.member.model.constants.ParameterKey;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,13 +27,8 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
 
-  private static final String LOGIN_URI = "/member/login";
-  private static final String EMAIL_KEY = "email";
-  private static final String PASSWORD_KEY = "password";
-  private static final String FCM_TOKEN_KEY = "fcmToken";
-
   private static final AntPathRequestMatcher LOGIN_REQUEST_MATCHER =
-      new AntPathRequestMatcher(LOGIN_URI, POST.name());
+      new AntPathRequestMatcher(LOGIN.getUri(), POST.name());
 
   public CustomLoginFilter(
       AuthenticationManager manager, AuthenticationSuccessHandler successHandler) {
@@ -61,15 +60,15 @@ public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
   }
 
   protected String obtainEmail(HttpServletRequest request) {
-    return request.getParameter(EMAIL_KEY);
+    return request.getParameter(ParameterKey.EMAIL.getKey());
   }
 
   protected String obtainPassword(HttpServletRequest request) {
-    return request.getParameter(PASSWORD_KEY);
+    return request.getParameter(PASSWORD.getKey());
   }
 
   protected String obtainFcmToken(HttpServletRequest request) {
-    return request.getParameter(FCM_TOKEN_KEY);
+    return request.getParameter(FCM_TOKEN.getKey());
   }
   // 로그인 성공 시 JWT 발급
   @Override

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/CustomLogoutFilter.java
@@ -2,6 +2,7 @@ package com.samcomo.dbz.member.jwt.filter;
 
 import static com.google.api.client.http.HttpMethods.POST;
 import static com.samcomo.dbz.global.exception.ErrorCode.ALREADY_LOGGED_OUT;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.COOKIE;
 import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
 
 import com.samcomo.dbz.member.exception.MemberException;
@@ -24,7 +25,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
   private final JwtUtil jwtUtil;
   private final CookieUtil cookieUtil;
 
-  private static final String LOGOUT_URI = "\\/member\\/logout";
+  private static final String LOGOUT_URI_REGEX = "\\/member\\/logout";
 
   public CustomLogoutFilter(AuthUtils authUtils) {
     this.jwtUtil = authUtils.getJwtUtil();
@@ -50,9 +51,9 @@ public class CustomLogoutFilter extends GenericFilterBean {
     validateRefreshToken(refreshToken);
 
     jwtUtil.deleteRefreshTokenFromDB(refreshToken);
-    response.setHeader(CookieUtil.COOKIE_KEY, cookieUtil.getNullCookie());
+    response.setHeader(COOKIE.getKey(), cookieUtil.getNullCookie());
     response.setStatus(HttpServletResponse.SC_OK);
-    log.info("[로그아웃 성공] {}", cookieUtil.getNullCookie());
+    log.info("[로그아웃 성공] {}", response.getHeader(COOKIE.getKey()));
   }
 
   private void validateRefreshToken(String refreshToken) {
@@ -66,6 +67,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
     if (!request.getMethod().equals(POST)) {
       return false;
     }
-    return request.getRequestURI().matches(LOGOUT_URI);
+    return request.getRequestURI().matches(LOGOUT_URI_REGEX);
   }
 }

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/RefreshTokenFilter.java
@@ -1,6 +1,7 @@
 package com.samcomo.dbz.member.jwt.filter;
 
 import static com.samcomo.dbz.global.exception.ErrorCode.REFRESH_TOKEN_NOT_FOUND;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.COOKIE;
 import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
 import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
 
@@ -32,7 +33,7 @@ public class RefreshTokenFilter {
     rotateRefreshToken(oldRefreshToken, newRefreshToken);
 
     response.setHeader(ACCESS_TOKEN.getKey(), newAccessToken);
-    response.addHeader(CookieUtil.COOKIE_KEY, cookieUtil.createCookie(newRefreshToken));
+    response.addHeader(COOKIE.getKey(), cookieUtil.createCookie(newRefreshToken));
     log.info("[토큰재발급 성공]");
   }
 

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/handler/LoginSuccessHandler.java
@@ -3,6 +3,7 @@ package com.samcomo.dbz.member.jwt.filter.handler;
 import static com.samcomo.dbz.global.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.samcomo.dbz.member.model.constants.LoginType.DEFAULT;
 import static com.samcomo.dbz.member.model.constants.LoginType.GOOGLE;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.COOKIE;
 import static com.samcomo.dbz.member.model.constants.TokenType.ACCESS_TOKEN;
 import static com.samcomo.dbz.member.model.constants.TokenType.REFRESH_TOKEN;
 
@@ -53,9 +54,10 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
     if (details.getLoginType() == DEFAULT) saveFcmToken(memberId, request);
 
     response.setHeader(ACCESS_TOKEN.getKey(), accessToken);
-    response.addHeader(CookieUtil.COOKIE_KEY, cookieUtil.createCookie(refreshToken));
+    response.addHeader(COOKIE.getKey(), cookieUtil.createCookie(refreshToken));
     response.setStatus(HttpServletResponse.SC_OK);
-    log.info("[로그인성공] {}", accessToken);
+    log.info("[로그인성공 헤더] {}", response.getHeader(ACCESS_TOKEN.getKey()));
+    log.info("[로그인성공 쿠키] {}", response.getHeader(COOKIE.getKey()));
   }
 
   private MemberDetails getMemberDetails(Authentication authResult) {

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/handler/Oauth2LoginFailureHandler.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/handler/Oauth2LoginFailureHandler.java
@@ -1,0 +1,20 @@
+package com.samcomo.dbz.member.jwt.filter.handler;
+
+import static com.samcomo.dbz.global.exception.ErrorCode.SOCIAL_AUTHENTICATION_FAILED;
+
+import com.samcomo.dbz.member.exception.MemberException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Oauth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)  {
+    throw new MemberException(SOCIAL_AUTHENTICATION_FAILED);
+  }
+}

--- a/src/main/java/com/samcomo/dbz/member/model/constants/ParameterKey.java
+++ b/src/main/java/com/samcomo/dbz/member/model/constants/ParameterKey.java
@@ -1,0 +1,18 @@
+package com.samcomo.dbz.member.model.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ParameterKey {
+
+  ID("id"),
+  EMAIL("email"),
+  ROLE("role"),
+  FCM_TOKEN("fcmToken"),
+  PASSWORD("password"),
+  COOKIE("Set-Cookie");
+
+  private final String key;
+}

--- a/src/main/java/com/samcomo/dbz/member/model/constants/UriKey.java
+++ b/src/main/java/com/samcomo/dbz/member/model/constants/UriKey.java
@@ -1,0 +1,14 @@
+package com.samcomo.dbz.member.model.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UriKey {
+
+  REISSUE("/member/reissue"),
+  LOGIN("/member/login");
+
+  private final String uri;
+}

--- a/src/main/java/com/samcomo/dbz/member/model/dto/oauth2/GoogleResponse.java
+++ b/src/main/java/com/samcomo/dbz/member/model/dto/oauth2/GoogleResponse.java
@@ -1,11 +1,15 @@
 package com.samcomo.dbz.member.model.dto.oauth2;
 
 import static com.samcomo.dbz.member.model.constants.LoginType.GOOGLE;
+import static com.samcomo.dbz.member.model.constants.ParameterKey.EMAIL;
 
 import com.samcomo.dbz.member.model.constants.LoginType;
 import java.util.Map;
 
 public class GoogleResponse implements Oauth2Response {
+
+  private final static String NICKNAME_KEY = "name";
+  private final static String PROFILE_IMAGE_KEY = "picture";
 
   private final Map<String, Object> attribute;
 
@@ -20,16 +24,16 @@ public class GoogleResponse implements Oauth2Response {
 
   @Override
   public String getEmail() {
-    return String.valueOf(attribute.get("email"));
+    return (String) attribute.get(EMAIL.getKey());
   }
 
   @Override
   public String getNickname() {
-    return String.valueOf(attribute.get("name")).replaceAll(" ", "");
+    return String.valueOf(attribute.get(NICKNAME_KEY)).replaceAll(" ", "");
   }
 
   @Override
   public String getProfileImageUrl() {
-    return String.valueOf(attribute.get("picture"));
+    return (String) attribute.get(PROFILE_IMAGE_KEY);
   }
 }


### PR DESCRIPTION
## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

### 소셜로그인 실패 시 커스텀 에러를 발생시키는 핸들러가 추가되었습니다.

구글 서버에서 내려주는 에러가 발생하면 저희 서비스의 커스텀 에러를 발생시킵니다.

```java
SOCIAL_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증에 실패했습니다.")
```

<br/><br/>

### 로그아웃 용 빈 쿠키 생성 시 samesite = none 처리 추가되었습니다.

```java
ResponseCookie.from(REFRESH_TOKEN.getKey(), null)
      .path("/")
      .maxAge(0)
      .sameSite(SAME_SITE_CONFIG) // 추가됨 ("None")
      .httpOnly(true)
      .secure(true)
      .build());
```

<br/><br/>

### final static 문자열을 enum 상수로 변환 후 호출하여 사용합니다.

```java
private static final String ID_KEY = "id";
private static final String EMAIL_KEY = "email";

ID("id"),
EMAIL("email")
```

여러 클래스에서 자주 사용하는 파라미터는 매번 클래스마다 호출하지 않고, enum 으로 분리하여 호출합니다.

