### PR TITLE
[Bug] 임시 서버에서 AuthO 로직 주석처리

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -86,10 +86,10 @@ public class SecurityConfig {
               }
             }));
 
-    http
-        .csrf((auth) -> auth.disable())
-        .formLogin((auth) -> auth.disable())
-        .httpBasic((auth) -> auth.disable());
+//    http
+//        .csrf((auth) -> auth.disable())
+//        .formLogin((auth) -> auth.disable())
+//        .httpBasic((auth) -> auth.disable());
 
     // mapping
     http

--- a/src/main/java/com/samcomo/dbz/member/jwt/filter/handler/Oauth2LoginFailureHandler.java
+++ b/src/main/java/com/samcomo/dbz/member/jwt/filter/handler/Oauth2LoginFailureHandler.java
@@ -1,20 +1,20 @@
-package com.samcomo.dbz.member.jwt.filter.handler;
-
-import static com.samcomo.dbz.global.exception.ErrorCode.SOCIAL_AUTHENTICATION_FAILED;
-
-import com.samcomo.dbz.member.exception.MemberException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
-import org.springframework.stereotype.Component;
-
-@Component
-public class Oauth2LoginFailureHandler implements AuthenticationFailureHandler {
-
-  @Override
-  public void onAuthenticationFailure(
-      HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)  {
-    throw new MemberException(SOCIAL_AUTHENTICATION_FAILED);
-  }
-}
+//package com.samcomo.dbz.member.jwt.filter.handler;
+//
+//import static com.samcomo.dbz.global.exception.ErrorCode.SOCIAL_AUTHENTICATION_FAILED;
+//
+//import com.samcomo.dbz.member.exception.MemberException;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import org.springframework.security.core.AuthenticationException;
+//import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//public class Oauth2LoginFailureHandler implements AuthenticationFailureHandler {
+//
+//  @Override
+//  public void onAuthenticationFailure(
+//      HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)  {
+//    throw new MemberException(SOCIAL_AUTHENTICATION_FAILED);
+//  }
+//}


### PR DESCRIPTION
```
2024-04-01T14:26:59.554Z ERROR 1 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 0 of method setFilterChains in org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration required a bean of type 'org.springframework.security.oauth2.client.registration.ClientRegistrationRepository' that could not be found.
```
환경변수값을 현재 서버에서 접속할수없어 임시 주석처리하였습니다.