### PR TITLE
refactor : 게시글 세부정보 전달 시 작성자의 프로필정보를 함께 반환하도록 수정

### DIFF
--- a/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
+++ b/src/main/java/com/samcomo/dbz/report/controller/ReportController.java
@@ -10,6 +10,7 @@ import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportSearchSummaryDto;
 import com.samcomo.dbz.report.model.dto.ReportStateDto;
 import com.samcomo.dbz.report.model.dto.ReportSummaryDto;
+import com.samcomo.dbz.report.model.dto.ReportWithProfile;
 import com.samcomo.dbz.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -53,11 +54,11 @@ public class ReportController {
   @GetMapping("/{reportId}")
   @LogMonitoringInvocation
   @Operation(summary = "특정 게시글 정보 가져오기")
-  public ResponseEntity<ReportDto.Response> getReport(
+  public ResponseEntity<ReportWithProfile> getReport(
       @AuthenticationPrincipal MemberDetails details,
       @PathVariable(value = "reportId") long reportId
   ) {
-    ReportDto.Response reportResponse = reportService.getReport(reportId, details.getId());
+    ReportWithProfile reportResponse = reportService.getReport(reportId, details.getId());
 
     return ResponseEntity.ok(reportResponse);
   }

--- a/src/main/java/com/samcomo/dbz/report/model/dto/ReportWithProfile.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/ReportWithProfile.java
@@ -1,0 +1,64 @@
+package com.samcomo.dbz.report.model.dto;
+
+import com.samcomo.dbz.report.model.constants.PetType;
+import com.samcomo.dbz.report.model.constants.ReportStatus;
+import com.samcomo.dbz.report.model.dto.ReportImageDto.Response;
+import com.samcomo.dbz.report.model.entity.Report;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class ReportWithProfile {
+
+  private Long reportId;
+  private WriterProfile writerProfile;
+  private String title;
+  private String petName;
+  private PetType petType;
+  private String species;
+  private String descriptions;
+  private String streetAddress;
+  private String roadAddress;
+  private Double latitude;
+  private Double longitude;
+  private String phone;
+  private Boolean showsPhone;
+  private Long views;
+  private ReportStatus reportStatus;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private List<Response> imageList;
+
+  public static ReportWithProfile from(Report report,
+      List<ReportImageDto.Response> reportImageResponseList, WriterProfile profile) {
+    return ReportWithProfile.builder()
+        .reportId(report.getId())
+        .writerProfile(profile)
+        .title(report.getTitle())
+        .petName(report.getPetName())
+        .petType(report.getPetType())
+        .species(report.getSpecies())
+        .descriptions(report.getDescription())
+        .streetAddress(report.getStreetAddress())
+        .roadAddress(report.getRoadAddress())
+        .latitude(report.getLatitude())
+        .longitude(report.getLongitude())
+        .phone(report.getShowsPhone() ? report.getMember().getPhone() : "X")
+        .showsPhone(report.getShowsPhone())
+        .views(report.getViews())
+        .reportStatus(report.getReportStatus())
+        .createdAt(report.getCreatedAt())
+        .updatedAt(report.getUpdatedAt())
+        .imageList(reportImageResponseList)
+        .build();
+  }
+}

--- a/src/main/java/com/samcomo/dbz/report/model/dto/WriterProfile.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/WriterProfile.java
@@ -1,0 +1,28 @@
+package com.samcomo.dbz.report.model.dto;
+
+import com.samcomo.dbz.member.model.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class WriterProfile {
+
+  private String nickname;
+  private String profileImageUrl;
+  private Long id;
+
+  public static WriterProfile from(Member member){
+    return WriterProfile.builder()
+        .id(member.getId())
+        .nickname(member.getNickname())
+        .profileImageUrl(member.getProfileImageUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/samcomo/dbz/report/service/ReportService.java
+++ b/src/main/java/com/samcomo/dbz/report/service/ReportService.java
@@ -5,13 +5,14 @@ import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportSearchSummaryDto;
 import com.samcomo.dbz.report.model.dto.ReportStateDto.Response;
 import com.samcomo.dbz.report.model.dto.ReportSummaryDto;
+import com.samcomo.dbz.report.model.dto.ReportWithProfile;
 import org.springframework.data.domain.Pageable;
 
 public interface ReportService {
 
   ReportDto.Response uploadReport(long memberId, ReportDto.Form reportForm);
 
-  ReportDto.Response getReport(long reportId, long memberId);
+  ReportWithProfile getReport(long reportId, long memberId);
 
   CustomSlice<ReportSummaryDto> getReportList(
       double lastLatitude, double lastLongitude, double curLatitude, double curLongitude, boolean showsInProcessOnly, Pageable pageable);

--- a/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
@@ -10,6 +10,7 @@ import com.samcomo.dbz.global.s3.service.S3Service;
 import com.samcomo.dbz.member.exception.MemberException;
 import com.samcomo.dbz.member.model.entity.Member;
 import com.samcomo.dbz.member.model.repository.MemberRepository;
+import com.samcomo.dbz.member.service.MemberService;
 import com.samcomo.dbz.notification.service.NotificationService;
 import com.samcomo.dbz.pin.model.entity.Pin;
 import com.samcomo.dbz.pin.model.repository.PinRepository;
@@ -17,11 +18,13 @@ import com.samcomo.dbz.report.exception.ReportException;
 import com.samcomo.dbz.report.model.constants.ReportStatus;
 import com.samcomo.dbz.report.model.dto.CustomPageable;
 import com.samcomo.dbz.report.model.dto.CustomSlice;
+import com.samcomo.dbz.report.model.dto.WriterProfile;
 import com.samcomo.dbz.report.model.dto.ReportDto;
 import com.samcomo.dbz.report.model.dto.ReportImageDto;
 import com.samcomo.dbz.report.model.dto.ReportSearchSummaryDto;
 import com.samcomo.dbz.report.model.dto.ReportStateDto;
 import com.samcomo.dbz.report.model.dto.ReportSummaryDto;
+import com.samcomo.dbz.report.model.dto.ReportWithProfile;
 import com.samcomo.dbz.report.model.dto.ReportWithUrl;
 import com.samcomo.dbz.report.model.entity.Report;
 import com.samcomo.dbz.report.model.entity.ReportImage;
@@ -53,6 +56,7 @@ public class ReportServiceImpl implements ReportService {
   private final NotificationService notificationService;
 
   private final PinRepository pinRepository;
+  private final MemberService memberService;
 
   @Override
   public ReportDto.Response uploadReport(long memberId, ReportDto.Form reportForm) {
@@ -89,7 +93,7 @@ public class ReportServiceImpl implements ReportService {
 
   @Override
   @DistributedLock(lockType = LockType.REPORT ,key = "redisLock", waitTime = 3L, leaseTime = 5L)
-  public ReportDto.Response getReport(long reportId, long memberId) {
+  public ReportWithProfile getReport(long reportId, long memberId) {
 
     Report report = reportRepository.findById(reportId)
         .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
@@ -107,7 +111,10 @@ public class ReportServiceImpl implements ReportService {
     }
 
     log.info("================Finish 조회수 : {}===================", newReport.getViews());
-    return ReportDto.Response.from(newReport, reportImageResponseList, report.getMember().getId());
+
+
+
+    return ReportWithProfile.from(newReport, reportImageResponseList, WriterProfile.from(report.getMember()));
   }
 
   @Override

--- a/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
+++ b/src/test/java/com/samcomo/dbz/report/service/ReportServiceTest.java
@@ -16,6 +16,7 @@ import com.samcomo.dbz.report.model.dto.ReportDto.Response;
 import com.samcomo.dbz.report.model.dto.ReportSearchSummaryDto;
 import com.samcomo.dbz.report.model.dto.ReportStateDto;
 import com.samcomo.dbz.report.model.dto.ReportSummaryDto;
+import com.samcomo.dbz.report.model.dto.ReportWithProfile;
 import com.samcomo.dbz.report.model.dto.ReportWithUrl;
 import com.samcomo.dbz.report.model.entity.Report;
 import com.samcomo.dbz.report.model.entity.ReportImage;
@@ -156,7 +157,7 @@ public class ReportServiceTest {
         ));
 
     //when
-    ReportDto.Response response = reportService.getReport(1L, member.getId());
+    ReportWithProfile response = reportService.getReport(1L, member.getId());
 
     //then
     Assertions.assertEquals(report.getId(), response.getReportId());


### PR DESCRIPTION
## 📌 Issues <!-- #issue number -->
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

<br/>

## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

> 프론트엔드 파트에서 게시글의 세부정보 조회 시 작성자의 프로필정보(ID, image, nickname)를 함께 넘겨줄 수 있도록 수정 요구
- "ReportWithProfile" DTO 객체에 "WriterProfile" 객체를 담아 반환하도록 수정
- 다음과 같이 "writerProfile"에 nickname, profileImageUrl, id 값을 담아 반환

```
"writerProfile" : {
    "nickname": "user1",
        "profileImageUrl": "defaultImageUrl.jpg",
        "id": 3
}
```
