### PR TITLE
[Refactor] chatRoomDto 필드 수정

### DIFF
--- a/src/main/java/com/samcomo/dbz/chat/model/dto/ChatRoomDto.java
+++ b/src/main/java/com/samcomo/dbz/chat/model/dto/ChatRoomDto.java
@@ -2,6 +2,7 @@ package com.samcomo.dbz.chat.model.dto;
 
 import com.samcomo.dbz.chat.model.entity.ChatRoom;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +14,22 @@ import lombok.Setter;
 public class ChatRoomDto {
 
   private String chatRoomId;
+  private List<Participant> participantList;
   private Set<String> memberIdList;
   private String lastMessageContent;
   private LocalDateTime lastMessageSentAt;
 
-  public static ChatRoomDto from(ChatRoom chatRoom) {
+  public static ChatRoomDto from(ChatRoom chatRoom, List<Participant> participantList) {
+    return ChatRoomDto.builder()
+        .chatRoomId(chatRoom.getChatRoomId())
+        .participantList(participantList)
+        .memberIdList(chatRoom.getMemberIdList())
+        .lastMessageContent(chatRoom.getLastMessageContent())
+        .lastMessageSentAt(chatRoom.getLastMessageSentAt())
+        .build();
+  }
+
+  public static ChatRoomDto from(ChatRoom chatRoom){
     return ChatRoomDto.builder()
         .chatRoomId(chatRoom.getChatRoomId())
         .memberIdList(chatRoom.getMemberIdList())

--- a/src/main/java/com/samcomo/dbz/chat/model/dto/Participant.java
+++ b/src/main/java/com/samcomo/dbz/chat/model/dto/Participant.java
@@ -1,0 +1,29 @@
+package com.samcomo.dbz.chat.model.dto;
+
+import com.samcomo.dbz.member.model.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Participant {
+
+  private Long id;
+  private String nickname;
+  private String profileImageUrl;
+  private boolean partner;
+
+  public static Participant from(Member member, boolean partner){
+    return Participant.builder()
+        .id(member.getId())
+        .nickname(member.getNickname())
+        .profileImageUrl(member.getProfileImageUrl())
+        .partner(partner)
+        .build();
+  }
+
+}

--- a/src/main/java/com/samcomo/dbz/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/chat/service/impl/ChatRoomServiceImpl.java
@@ -4,17 +4,20 @@ import static com.samcomo.dbz.global.exception.ErrorCode.CHAT_MESSAGE_NOT_FOUND;
 
 import com.samcomo.dbz.chat.exception.ChatException;
 import com.samcomo.dbz.chat.model.dto.ChatRoomDto;
+import com.samcomo.dbz.chat.model.dto.Participant;
 import com.samcomo.dbz.chat.model.entity.ChatMessage;
 import com.samcomo.dbz.chat.model.entity.ChatRoom;
 import com.samcomo.dbz.chat.model.repository.ChatMessageRepository;
 import com.samcomo.dbz.chat.model.repository.ChatRoomRepository;
 import com.samcomo.dbz.chat.service.ChatRoomService;
 import com.samcomo.dbz.chat.util.ChatUtils;
+import com.samcomo.dbz.member.model.entity.Member;
+import com.samcomo.dbz.member.service.MemberService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   private final ChatRoomRepository chatRoomRepository;
   private final ChatMessageRepository chatMessageRepository;
   private final ChatUtils chatUtils;
+  private final MemberService memberService;
 
   @Override
   @Transactional
@@ -52,9 +56,26 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Transactional(readOnly = true)
   public List<ChatRoomDto> getChatRoomsFromMember(String memberId) {
     // 채팅방 리스트 불러오기 ( 최신 업데이트된 메시지 순서 )
-    return chatRoomRepository.findByMemberIdSortedByLastChatMessageAtDesc(memberId)
-        .stream().map(ChatRoomDto::from)
-        .collect(Collectors.toList());
+
+    List<ChatRoom> chatRoomList =
+        chatRoomRepository.findByMemberIdSortedByLastChatMessageAtDesc(memberId);
+
+
+    List<ChatRoomDto> chatRoomDtoList = new ArrayList<>();
+    for (ChatRoom chatRoom : chatRoomList) {
+
+      List<Participant> participantList = chatRoom.getMemberIdList().stream()
+          .map(participantId -> {
+            Member member = memberService.getMember(Long.parseLong(participantId));
+            return Participant.from(member, !memberId.equals(participantId));
+          })
+          .toList();
+
+      chatRoomDtoList.add(ChatRoomDto.from(chatRoom, participantList));
+    }
+
+
+    return chatRoomDtoList;
   }
 
   @Override

--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -101,7 +101,8 @@ public class SecurityConfig {
                 "/v3/api-docs/**",
                 "/aop/",
                 "/actuator/**",
-                "/ws/**"
+                "/ws/**",
+                "/chat/room"
             ).permitAll()
             // member
             .requestMatchers(GET, "/member/my").hasRole(MEMBER) // 마이페이지

--- a/src/main/java/com/samcomo/dbz/report/model/dto/ReportWithProfile.java
+++ b/src/main/java/com/samcomo/dbz/report/model/dto/ReportWithProfile.java
@@ -20,6 +20,7 @@ import lombok.Setter;
 public class ReportWithProfile {
 
   private Long reportId;
+  private Long memberId;
   private WriterProfile writerProfile;
   private String title;
   private String petName;
@@ -39,9 +40,10 @@ public class ReportWithProfile {
   private List<Response> imageList;
 
   public static ReportWithProfile from(Report report,
-      List<ReportImageDto.Response> reportImageResponseList, WriterProfile profile) {
+      List<ReportImageDto.Response> reportImageResponseList, WriterProfile profile, long memberId) {
     return ReportWithProfile.builder()
         .reportId(report.getId())
+        .memberId(memberId)
         .writerProfile(profile)
         .title(report.getTitle())
         .petName(report.getPetName())

--- a/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/report/service/impl/ReportServiceImpl.java
@@ -114,7 +114,7 @@ public class ReportServiceImpl implements ReportService {
 
 
 
-    return ReportWithProfile.from(newReport, reportImageResponseList, WriterProfile.from(report.getMember()));
+    return ReportWithProfile.from(newReport, reportImageResponseList, WriterProfile.from(report.getMember()), memberId);
   }
 
   @Override


### PR DESCRIPTION
## 📌 Issues <!-- #issue number -->
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

<br/>

## ✨ Description
#### 기존 ChatRoomDto에는 채팅 참여자의 아이디값만 존재해서 참가자의 닉네임과 프로필이미지를 사용할 수 없었음.
- ChatRoomDto에 ParticipantList 추가하여 채팅 참여자들의 id, 프로필 이미지 URL, 닉네임을 담을 수 있도록 수정

``` java
participantList: [
    participant: {
        id: 1, // 참가자의 ID
        nickname: 니네임1, // 참가자의 닉네임
        profileImageUrl: http://www.imageUrl.com, // 참가자의 프로필 이미지 URL
        partner: false // 대화 상대인지 판단 => false : 요청자일 때, true : 상대방일 때
    },
    participant: {
        id: 2,
        nickname: 니네임2,
        profileImageUrl: http://www.imageUrl.com,
        partner: true
    }
]

```