### PR TITLE
[Fix] getChatRoomsFromMember() 자료형 오류

### DIFF
--- a/src/main/java/com/samcomo/dbz/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/samcomo/dbz/chat/service/impl/ChatRoomServiceImpl.java
@@ -60,20 +60,23 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     List<ChatRoom> chatRoomList =
         chatRoomRepository.findByMemberIdSortedByLastChatMessageAtDesc(memberId);
 
-
     List<ChatRoomDto> chatRoomDtoList = new ArrayList<>();
     for (ChatRoom chatRoom : chatRoomList) {
 
-      List<Participant> participantList = chatRoom.getMemberIdList().stream()
-          .map(participantId -> {
-            Member member = memberService.getMember(Long.parseLong(participantId));
-            return Participant.from(member, !memberId.equals(participantId));
-          })
-          .toList();
+      List<Participant> participantList = new ArrayList<>();
+
+      for (String participantId : chatRoom.getMemberIdList()) {
+        log.info("participantId : {}", participantId);
+        Arrays.stream(participantId.split(","))
+            .forEach(id -> {
+              Member member = memberService.getMember(Long.parseLong(participantId));
+              participantList.add(Participant.from(member, !memberId.equals(participantId)));
+            });
+
+      }
 
       chatRoomDtoList.add(ChatRoomDto.from(chatRoom, participantList));
     }
-
 
     return chatRoomDtoList;
   }


### PR DESCRIPTION
## 📌 Issues <!-- #issue number -->
<!-- 제목 옆에 주석을 지우고 관련있는 이슈 번호(#000)를 적어주세요. 
해당 pull request merge 와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->

<br/>

## ✨ Description
<!-- 추가한 라이브러리와 이유 등을 포함하여 핵심 구현 사항을 적어주세요. -->

String -> Long 
문자열을 Long 타입으로 변형하는 부분에서 NumberFormatException 발생

[원인]
- memberIdList의 값이 문자열로 넘어오는데 "4,4" 이런 방식으로 넘어오면서 Long 타입으로 변환이 안되었던 것이 문제점
- split()을 사용하여 하나의 Long타입으로 변환할 수 있도록 수정