### PR TITLE
CorsMvcConfigTest: CORS origin 추가

### DIFF
--- a/src/main/java/com/samcomo/dbz/global/config/CorsMvcConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/CorsMvcConfig.java
@@ -11,6 +11,6 @@ public class CorsMvcConfig implements WebMvcConfigurer {
   public void addCorsMappings(CorsRegistry corsRegistry){
 
     corsRegistry.addMapping("/**")
-        .allowedOrigins("http://localhost:5173");
+        .allowedOrigins("http://localhost:3000","http://localhost:5173","https://samcomo.site");
   }
 }

--- a/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
+++ b/src/main/java/com/samcomo/dbz/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import com.samcomo.dbz.member.jwt.filter.handler.Oauth2LoginFailureHandler;
 import com.samcomo.dbz.member.service.impl.Oauth2MemberServiceImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -75,7 +76,7 @@ public class SecurityConfig {
 
                 CorsConfiguration configuration = new CorsConfiguration();
 
-                configuration.setAllowedOrigins(Collections.singletonList("http://localhost:5173"));
+                configuration.setAllowedOrigins(List.of("http://localhost:5173","http://localhost:3000","https://samcomo.site"));
                 configuration.setAllowedMethods(Collections.singletonList("*"));
                 configuration.setAllowCredentials(true);
                 configuration.setAllowedHeaders(Collections.singletonList("*"));


### PR DESCRIPTION
CorsMvcConfig.java 파일에서 허용된 출처(origin) 목록 업데이트

- http://localhost:5173만 허용 ->  http://localhost:3000, - http://localhost:5173, https://samcomo.site로 확장

- SecurityConfig.java 파일에서 CORS 설정의 허용된 출처 업데이트
    -  http://localhost:5173 허용 -> http://localhost:3000, http://localhost:5173, https://samcomo.site 허용